### PR TITLE
Local vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ fn main() {
 }
 ```
 
-Because manipulating items solely on the stack can become very tedious (not to mention adds a significant mental burden), you are able to create scoped variables using the `var [ident ..]` syntax. Variables will last for the duration of their scope, and are cosumed from the top of the stack. 
+Because manipulating items solely on the stack can become very tedious (not to mention adds a significant mental burden), you are able to create scoped variables using the `as [ident ..]` syntax. Variables will last for the duration of their scope, and are cosumed from the top of the stack. 
 
 ```
 fn main() {
     1 2
-    var [one two]
+    as [one two]
     one print
     two print
     two print
@@ -77,7 +77,7 @@ The syntax is: `<cond> if { ... } else ... <cond> if { ... } else { ... }`
 // This compiles fine
 fn main() {
 
-    1 2 var [a b]
+    1 2 as [a b]
     a b < if {
         a
     } else a b > if {
@@ -110,7 +110,7 @@ Only `while` loops are supported at this time.
 // prints number up to 10
 fn main() {
     0 while dup 10 < {
-        var [i]
+        as [i]
         i print
         i 1 +
     } drop
@@ -191,7 +191,7 @@ fn main() {
 }
 ```
 
-You can access struct members directly if the struct is bound to a `var`:
+You can access struct members directly if the struct has been bound with an `as` block:
 
 ```
 include "std.hay"
@@ -203,7 +203,7 @@ struct Pair<T> {
 fn main() {
 
     "Hello\n" "World\n" cast(Pair)
-    var [pair]
+    as [pair]
 
     pair::first::size print
 
@@ -251,9 +251,9 @@ fn main() {
 ```
 fn main() {
     
-    100 var [n]
+    100 as [n]
     0 while dup n < {
-        var [i]
+        as [i]
         i print
         i 1 +
     }

--- a/examples/array.hay
+++ b/examples/array.hay
@@ -4,14 +4,14 @@ var Str[1024]: strings
 
 fn main() {
 
-    strings @ var [strs]
+    strings @ as [strs]
 
     "Hello World1\n" 0 strs Arr.set
     "Hello World2\n" 1 strs Arr.set
     "Hello World3\n" 2 strs Arr.set
 
     0 while dup 3 < {
-        var [i]
+        as [i]
         i strs Arr.get write
         i 1 + 
     } drop

--- a/examples/branching.hay
+++ b/examples/branching.hay
@@ -1,7 +1,7 @@
 
 fn main() {
 
-    3 2 var [a b]
+    3 2 as [a b]
 
     a b < if {
         1

--- a/examples/fib.hay
+++ b/examples/fib.hay
@@ -9,7 +9,7 @@ fn fib(u64: x) -> [u64] {
 
 fn main() {
     0 while dup 20 < {
-        var [i]
+        as [i]
         i fib print
         i 1 +
     } drop

--- a/examples/local.hay
+++ b/examples/local.hay
@@ -1,23 +1,29 @@
 include "std.hay"
 
+
 fn foo(Str: s) {
+    var u8[100]: nums
+    
+    nums @ as [arr]
+    arr::data arr::size ptr- as [front]
+    arr::size print
+    arr::data cast(u64) print
+    front cast(u64) print
 
-    var u8[100]: bytes
-    var u64: size
-
-    bytes @ as [arr]
-
-    s::size size ! 
     0 while dup s::size < {
         as [i]
-        s::data i ptr+ @ i arr Arr.set
-        i 1 +
+        s::data i ptr+ @ as [char]
+        
+        char front i ptr+ ! 
+        
+        i 1 + 
     } drop
 
-    size @ arr::data cast(Str) write
+    s::size front cast(Str) write
+    
+    s write
 }
 
 fn main() {
     "Hello Local!\n" foo
-    "1234567890\n" foo
 }

--- a/examples/local.hay
+++ b/examples/local.hay
@@ -1,0 +1,21 @@
+
+
+fn foo(Str: s) {
+
+    var Str[100]: data
+    var u64: size
+
+    s::size size ! 
+    0 while dup s::size < {
+        as [i]
+        s::data i ptr+ @
+           data i ptr+ ! 
+    } drop
+
+    size data cast(Str) write
+}
+
+fn main() {
+    "Hello Local!\n" foo
+    "1234567890\n" foo
+}

--- a/examples/local.hay
+++ b/examples/local.hay
@@ -4,7 +4,7 @@ include "std.hay"
 fn copy_local(Str: s) {
     var u8[100]: nums
     nums @ as [local]
-    
+
     0 while dup s::size < {
         as [i]
         s::data i ptr+ @

--- a/examples/local.hay
+++ b/examples/local.hay
@@ -1,18 +1,20 @@
-
+include "std.hay"
 
 fn foo(Str: s) {
 
-    var Str[100]: data
+    var u8[100]: bytes
     var u64: size
+
+    bytes @ as [arr]
 
     s::size size ! 
     0 while dup s::size < {
         as [i]
-        s::data i ptr+ @
-           data i ptr+ ! 
+        s::data i ptr+ @ i arr Arr.set
+        i 1 +
     } drop
 
-    size data cast(Str) write
+    size @ arr::data cast(Str) write
 }
 
 fn main() {

--- a/examples/loop.hay
+++ b/examples/loop.hay
@@ -1,7 +1,7 @@
 fn main() {
-    100 var [n]
+    100 as [n]
     0 while dup n < {
-        var [i]
+        as [i]
         i print
         i 1 + 
     } drop

--- a/examples/pointer.hay
+++ b/examples/pointer.hay
@@ -1,8 +1,8 @@
 fn main() {
 
-    "hello World!\n" var [word]
+    "hello World!\n" as [word]
     0 while dup word::size < {
-        var [i]
+        as [i]
         word::data i ptr+ @ print
         i 1 + 
         

--- a/src/compiler/x86_64.rs
+++ b/src/compiler/x86_64.rs
@@ -373,7 +373,7 @@ fn nasm_close(
     writeln!(file, "segment .bss").unwrap();
     writeln!(file, "  frame_start_ptr: resq 1").unwrap();
     writeln!(file, "  frame_end_ptr: resq 1").unwrap();
-    writeln!(file, "  frame_stack: resq 2048").unwrap();
+    writeln!(file, "  frame_stack: resq 65536").unwrap();
     writeln!(file, "  frame_stack_end:").unwrap();
     uninit_data
         .iter()

--- a/src/compiler/x86_64.rs
+++ b/src/compiler/x86_64.rs
@@ -216,10 +216,19 @@ fn compile_op(
         OpKind::PushIdent { .. } => {
             panic!("Push ident should have been transformed into PushFramed")
         }
+        OpKind::PushLocal(_) => {
+            panic!("Push ident should have been transformed into PushFramed")
+        }
+        OpKind::PushLocalPtr(offset) => {
+            writeln!(file, "  mov  rax, [frame_start_ptr - {offset}]").unwrap();
+            writeln!(file, "  push rax").unwrap();
+        }
         OpKind::PushFramed { offset, size } => {
+            let locals_offset = Function::locals_offset(&func.unwrap().locals);
+
             for delta in 0..*size {
                 let x = offset + size - delta;
-                writeln!(file, "  mov  rax, [frame_start_ptr]").unwrap();
+                writeln!(file, "  mov  rax, [frame_start_ptr - {locals_offset}]").unwrap();
                 writeln!(file, "  mov  rax, [rax - {}]", (1 + x) * 8).unwrap();
                 writeln!(file, "  push rax").unwrap();
             }

--- a/src/compiler/x86_64.rs
+++ b/src/compiler/x86_64.rs
@@ -220,7 +220,6 @@ fn compile_op(
             panic!("Push ident should have been transformed into PushFramed")
         }
         OpKind::PushLocalPtr(offset) => {
-            println!("Local Ptr Offset: {offset}");
             writeln!(file, "  mov  rax, [frame_start_ptr]").unwrap();
             writeln!(file, "  sub  rax,  {}", offset + 8).unwrap();
             writeln!(file, "  push rax").unwrap();
@@ -269,15 +268,16 @@ fn compile_op(
             writeln!(file, "  pop  rax").unwrap();
             frame_push_rax(file);
             let locals = &func.unwrap().locals;
+
             for (_, local) in locals {
                 writeln!(file, "  ; -- Local {:?}", local).unwrap();
                 if let Some(data) = &local.value {
                     match data {
                         InitData::Arr { size, pointer } => {
-                            let (_, pointer) =
+                            let (_, ptr_offset) =
                                 Function::locals_get_offset(pointer, &func.unwrap().locals);
-                            writeln!(file, "  mov  rax, [frame_end_ptr]").unwrap();
-                            writeln!(file, "  sub  rax, {}", pointer + 8).unwrap();
+                            writeln!(file, "  mov  rax, [frame_start_ptr]").unwrap();
+                            writeln!(file, "  sub  rax, {}", ptr_offset + 8).unwrap();
                             frame_push_rax(file);
                             writeln!(file, "  mov  rax, {size}").unwrap();
                             frame_push_rax(file);

--- a/src/ir/data.rs
+++ b/src/ir/data.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Serialize, Deserialize, Clone)]
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub enum InitData {
     String(String),
     Arr { size: u64, pointer: String },

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -1,5 +1,6 @@
 use crate::compiler::{compiler_error, type_check_ops_list};
 use crate::ir::{
+    data::InitData,
     op::Op,
     token::Token,
     types::{Signature, Type},
@@ -9,6 +10,13 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+pub struct LocalVar {
+    pub typ: Type,
+    pub size: u64,
+    pub value: Option<InitData>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Function {
     pub name: String,
     pub token: Token,
@@ -16,6 +24,7 @@ pub struct Function {
     pub sig: Signature,
     pub ops: Vec<Op>,
     pub gen_map: HashMap<String, Type>,
+    pub locals: HashMap<String, LocalVar>,
 }
 
 impl Function {
@@ -156,6 +165,7 @@ impl Function {
             sig,
             ops: new_ops,
             gen_map: map,
+            locals: HashMap::new(),
         }
     }
 }

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -33,19 +33,15 @@ impl Function {
     }
 
     pub fn locals_offset(locals: &BTreeMap<String, LocalVar>) -> usize {
-        locals
-            .iter()
-            .map(|(_, local)| local.typ.size() * local.typ.width())
-            .sum()
+        locals.iter().map(|(_, local)| local.size as usize).sum()
     }
 
     pub fn locals_get_offset(ident: &String, locals: &BTreeMap<String, LocalVar>) -> (Type, usize) {
         let mut size = 0;
         for (loc_name, local) in locals {
+            size += local.size;
             if ident == loc_name {
-                return (local.typ.clone(), size);
-            } else {
-                size += local.typ.size() * local.typ.width()
+                return (local.typ.clone(), size as usize);
             }
         }
         panic!("didn't find {ident} in locals");

--- a/src/ir/keyword.rs
+++ b/src/ir/keyword.rs
@@ -4,6 +4,7 @@ use serde::{Deserialize, Serialize};
 pub enum Keyword {
     Function,
     Var,
+    As,
     If,
     Else,
     While,

--- a/src/ir/op.rs
+++ b/src/ir/op.rs
@@ -305,10 +305,7 @@ impl Op {
                 );
 
                 let n = typ.size();
-                let width = match *typ {
-                    Type::U8 => 1,
-                    _ => 8,
-                };
+                let width = typ.width();
 
                 self.kind = OpKind::Read(Some((n, width)));
 
@@ -338,10 +335,7 @@ impl Op {
                 );
 
                 let n = typ.size();
-                let width = match *typ {
-                    Type::U8 => 1,
-                    _ => 8,
-                };
+                let width = typ.width();
 
                 self.kind = OpKind::Write(Some((n, width)));
                 None
@@ -356,10 +350,7 @@ impl Op {
                     Type::assign_generics(&self.token, typ, gen_map)
                 };
 
-                let size = match typ_after {
-                    Type::U8 => 1,
-                    _ => typ_after.size() * 8,
-                };
+                let size = typ_after.size() * typ_after.width();
 
                 self.kind = OpKind::PushInt(size as u64);
                 evaluate_signature(

--- a/src/ir/program.rs
+++ b/src/ir/program.rs
@@ -224,6 +224,8 @@ impl Program {
                             };
                         } else if fn_names.get(s).is_some() {
                             op.kind = OpKind::Call(s.clone());
+                        } else if func.locals.get(s).is_some() {
+                            op.kind = OpKind::PushLocal(s.clone());
                         } else if self.global_vars.get(s).is_some() {
                             op.kind = OpKind::Global(s.clone());
                         } else {

--- a/src/ir/token.rs
+++ b/src/ir/token.rs
@@ -55,6 +55,7 @@ impl From<(LogosToken, &str)> for TokenKind {
             // Keywords
             (LogosToken::FunctionKeyword, _) => TokenKind::Keyword(Keyword::Function),
             (LogosToken::VarKeyword, _) => TokenKind::Keyword(Keyword::Var),
+            (LogosToken::AsKeyword, _) => TokenKind::Keyword(Keyword::As),
             (LogosToken::IfKeyword, _) => TokenKind::Keyword(Keyword::If),
             (LogosToken::ElseKeyword, _) => TokenKind::Keyword(Keyword::Else),
             (LogosToken::WhileKeyword, _) => TokenKind::Keyword(Keyword::While),

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -63,6 +63,13 @@ impl Type {
         }
     }
 
+    pub fn width(&self) -> usize {
+        match self {
+            Type::U8 => 1,
+            _ => 8,
+        }
+    }
+
     pub fn str() -> Self {
         Type::Struct {
             name: String::from("Str"),

--- a/src/lex/lexer.rs
+++ b/src/lex/lexer.rs
@@ -968,7 +968,7 @@ fn parse_local_var(
 
             let arr_local = LocalVar {
                 typ: arr_ptr_typ.clone(),
-                size: arr_typ.size() as u64,
+                size: (arr_typ.size() * arr_typ.width()) as u64,
                 value: Some(InitData::Arr {
                     size: n,
                     pointer: format!("{ident}_data"),
@@ -993,13 +993,11 @@ fn parse_local_var(
                 )
             };
         } else {
-            let typ = Type::Pointer {
-                typ: Box::new(typ.clone()),
-            };
-
             let local = LocalVar {
-                typ: typ.clone(),
-                size: typ.size() as u64,
+                typ: Type::Pointer {
+                    typ: Box::new(typ.clone()),
+                },
+                size: (typ.size() * typ.width()) as u64,
                 value: None,
             };
 

--- a/src/lex/lexer.rs
+++ b/src/lex/lexer.rs
@@ -54,9 +54,13 @@ fn parse_tokens_until_tokenkind(
         }
 
         match token.kind {
-            TokenKind::Keyword(Keyword::Var) => {
-                let (_tok, mut idents) = parse_var(&token, tokens);
+            TokenKind::Keyword(Keyword::As) => {
+                let (_tok, mut idents) = parse_let(&token, tokens);
                 ops.append(&mut idents);
+            }
+            TokenKind::Keyword(Keyword::Var) => {
+                todo!();
+                //parse_local_var(token, tokens, type_map, globals, init_data)
             }
             TokenKind::Keyword(Keyword::Cast) => {
                 let op = parse_cast(&token, tokens, type_map);
@@ -573,7 +577,7 @@ fn parse_cast(start_tok: &Token, tokens: &mut Vec<Token>, type_map: &HashMap<Str
     }
 }
 
-fn parse_var(start_tok: &Token, tokens: &mut Vec<Token>) -> (Token, Vec<Op>) {
+fn parse_let(start_tok: &Token, tokens: &mut Vec<Token>) -> (Token, Vec<Op>) {
     let (tok, idents) = parse_word_list(start_tok, tokens);
     if idents.is_empty() {
         compiler_error(

--- a/src/lex/lexer.rs
+++ b/src/lex/lexer.rs
@@ -13,7 +13,7 @@ use crate::ir::{
 };
 use crate::lex::logos_lex::{into_token, LogosToken};
 use logos::Logos;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 
 fn escape_string(unescaped: &str) -> String {
@@ -46,7 +46,7 @@ fn parse_tokens_until_tokenkind(
     ops: &mut Vec<Op>,
     type_map: &HashMap<String, Type>,
     init_data: &mut HashMap<String, InitData>,
-    mut maybe_locals: Option<&mut HashMap<String, LocalVar>>,
+    mut maybe_locals: Option<&mut BTreeMap<String, LocalVar>>,
     break_on: Vec<TokenKind>,
 ) -> Token {
     while let Some(token) = tokens.pop() {
@@ -650,7 +650,7 @@ fn parse_function(
         }
     });
 
-    let mut locals: HashMap<String, LocalVar> = HashMap::new();
+    let mut locals: BTreeMap<String, LocalVar> = BTreeMap::new();
     let tok = parse_tokens_until_tokenkind(
         &tok,
         tokens,
@@ -942,7 +942,7 @@ fn parse_local_var(
     token: &Token,
     tokens: &mut Vec<Token>,
     type_map: &HashMap<String, Type>,
-    locals: &mut HashMap<String, LocalVar>,
+    locals: &mut BTreeMap<String, LocalVar>,
 ) {
     if let Some((tok, ident, typ, array_n)) = parse_tagged_type(token, tokens, type_map) {
         if let Some(n) = array_n {

--- a/src/lex/logos_lex.rs
+++ b/src/lex/logos_lex.rs
@@ -33,6 +33,8 @@ pub enum LogosToken {
     FunctionKeyword,
     #[token("var")]
     VarKeyword,
+    #[token("as")]
+    AsKeyword,
     #[token("if")]
     IfKeyword,
     #[token("else")]

--- a/src/libs/prelude.hay
+++ b/src/libs/prelude.hay
@@ -2,5 +2,8 @@ fn drop<T>(T: t) {}
 fn dup<T>(T: t) -> [T T]{ t t }
 fn swap<A B>(A: a B: b) -> [B A] { b a }
 fn ptr+<T>(*T: ptr u64: n) -> [*T] {
-    ptr cast(u64) n + cast(*T) 
+    ptr cast(u64) sizeOf(T) n * + cast(*T) 
+}
+fn ptr-<T>(*T: ptr u64: n) -> [*T] {
+    ptr cast(u64) sizeOf(T) n * - cast(*T) 
 }

--- a/src/libs/std.hay
+++ b/src/libs/std.hay
@@ -21,7 +21,7 @@ fn Arr.set<T>(T: value u64: idx Arr<T>: arr) {
         idx print
         1 exit
     }
-    value arr::data sizeOf(T) idx * ptr+  !
+    value arr::data idx ptr+ !
 }
 
 fn Arr.get<T>(u64: idx Arr<T>: arr) -> [T] {
@@ -30,5 +30,5 @@ fn Arr.get<T>(u64: idx Arr<T>: arr) -> [T] {
         idx print
         1 exit
     }
-    arr::data sizeOf(T) idx * ptr+ @
+    arr::data idx ptr+ @
 }

--- a/src/tests/array.hay
+++ b/src/tests/array.hay
@@ -4,23 +4,23 @@ var Str[1024]: strings
 
 fn main() {
 
-    strings @ var [x]
+    strings @ as [x]
 
     "Hello World1\n" 0 x Arr.set
     "Hello World2\n" 1 x Arr.set
     "Hello World3\n" 2 x Arr.set
 
     0 while dup 3 < {
-        var [i]
+        as [i]
         i x Arr.get write
         i 1 + 
     } drop
     
     "aaaaabbbbbccccc" split cast(Arr)
-    var [str_arr]
+    as [str_arr]
 
     0 while dup str_arr::size < {
-        var [i]
+        as [i]
         i str_arr Arr.get print
         i 1 +
     } drop

--- a/src/tests/empty_file.try_com
+++ b/src/tests/empty_file.try_com
@@ -1,5 +1,0 @@
-{
-  "exit_code": 1,
-  "stdout": "",
-  "stderr": "src/libs/prelude.hay:4:8: ERROR: No entry point defined\n    Note: Try adding a `main` function.\n"
-}

--- a/src/tests/if_else.hay
+++ b/src/tests/if_else.hay
@@ -1,6 +1,6 @@
 fn main() {
 
-    1 2 var[a b]
+    1 2 as[a b]
 
     a b > if {
         1

--- a/src/tests/local.hay
+++ b/src/tests/local.hay
@@ -3,18 +3,23 @@ include "std.hay"
 
 fn copy_local(Str: s) {
     var u8[100]: nums
-    nums @ as [local]
+    
+    nums @ as [arr]
     
     0 while dup s::size < {
         as [i]
         s::data i ptr+ @
-        i local Arr.set
+        i arr Arr.set
         1 i +
     } drop
 
+    s::size arr::data cast(Str) write
+    s::size arr::data cast(Arr) nums !
+    s::size arr::data cast(Str) write
+
     nums @ as [updated]
     updated::size updated::data cast(Str) write
-    s write
+    //s::size arr::data cast(Arr) nums !
 }
 
 fn main() {

--- a/src/tests/local.try_com
+++ b/src/tests/local.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/local.asm\n[CMD]: ld -o local src/tests/local.o\n",
+  "stderr": ""
+}

--- a/src/tests/local.try_run
+++ b/src/tests/local.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "Hello Local!\nHello Local!\nHello Local!\nFoo123456789012345678890!\nFoo123456789012345678890!\nFoo123456789012345678890!\n",
+  "stderr": ""
+}

--- a/src/tests/pointer.hay
+++ b/src/tests/pointer.hay
@@ -1,9 +1,9 @@
 include "std.hay"
 fn main() {
 
-    "hello World!\n" var [word]
+    "hello World!\n" as [word]
     0 while dup word::size < {
-        var [i]
+        as [i]
         word::data i ptr+ @ print
         88 cast(u8) word::data i ptr+ !
         i 1 + 

--- a/src/tests/struct_accessors.hay
+++ b/src/tests/struct_accessors.hay
@@ -8,7 +8,7 @@ struct Words {
 
 fn main() {
     "Hello\n" "World!\n" cast(Words)
-    var [words]
+    as [words]
 
     words::hello write
     words::world write


### PR DESCRIPTION
Some Linux syscalls require pointers to some c data structures. In order to not reserve the space globally, it was nice to be able to reserve small amounts of memory on the frame_stack.

Now the stack frame looks like this:
[ idents, .. | local variables, .. | rsp | prev_frame_ptr ]

Since `var` is being used to reserve global variables, I changed the `var [idents ... ]` syntax to `as [idents ... ]` instead. 

Here's how you'd use it:
```
fn foo() {
    // Works the same as global var
    var u64[100]: bytes
    var bool: condition
    bytes @ as [array] // bytes will still push a pointer to an Arr<u64> 
    array::size print

    13 array::data 5 ptr+ ! 

    true condition ! //
    condition @ if {
        // ...
    }
}
