### PR TITLE
Unions

### DIFF
--- a/examples/union.hay
+++ b/examples/union.hay
@@ -1,0 +1,15 @@
+include "std.hay"
+union Foo {
+    u64: x
+    Str: s
+}
+
+fn main() {
+
+    69 cast(Foo) as [foo_u64]
+    "Hello World" cast(Foo) as [foo_str]
+
+    foo_u64::x putlnu
+    foo_str::x putlns
+
+}

--- a/examples/union.hay
+++ b/examples/union.hay
@@ -5,14 +5,11 @@ union Foo {
 }
 
 fn main() {
-    17
     69 cast(Foo) as [foo_u64]
     "Hello World" cast(Foo) as [foo_str]
-
-    foo_u64::s as [bad]
-    bad::data cast(u64) putlnu
-    bad::size cast(u64) putlnu
-    foo_str::s putlns
-    drop
+    "Foo as u64: " puts foo_u64::x putlnu
+    "Bad::data: "  puts foo_u64::s::data cast(u64) putlnu
+    "Bad::size: "  puts foo_u64::s::size putlnu
+    "Foo as str: " puts foo_str::s putlns
 
 }

--- a/examples/union.hay
+++ b/examples/union.hay
@@ -5,11 +5,14 @@ union Foo {
 }
 
 fn main() {
-
+    17
     69 cast(Foo) as [foo_u64]
     "Hello World" cast(Foo) as [foo_str]
 
-    foo_u64::x putlnu
-    foo_str::x putlns
+    foo_u64::s as [bad]
+    bad::data cast(u64) putlnu
+    bad::size cast(u64) putlnu
+    foo_str::s putlns
+    drop
 
 }

--- a/src/compiler/x86_64.rs
+++ b/src/compiler/x86_64.rs
@@ -199,6 +199,11 @@ fn compile_op(
             unreachable!("SizeOf should have been converted into PushInt by code generation.")
         }
         OpKind::Cast(_) => (),
+        OpKind::Pad(n) => {
+            for _ in 0..*n {
+                writeln!(file, "  push 0").unwrap();
+            }
+        }
         OpKind::Split => (),
         OpKind::Global(s) => write!(file, "  push {s}").unwrap(),
         OpKind::Word(_) => unreachable!("Words shouldn't be compiled."),

--- a/src/ir/keyword.rs
+++ b/src/ir/keyword.rs
@@ -9,6 +9,7 @@ pub enum Keyword {
     Else,
     While,
     Struct,
+    Union,
     Cast,
     Split,
     Syscall,

--- a/src/ir/op.rs
+++ b/src/ir/op.rs
@@ -118,7 +118,6 @@ impl Op {
     fn get_type_from_frame(&self, frame: &Frame, index: usize, inner: &[String]) -> (Type, usize) {
         let mut t = frame[index].clone();
         let mut t_offset: usize = frame[0..index].iter().map(|t| t.size() * t.width()).sum();
-        println!("Frame: {:?}", frame);
         for field in inner {
             let (new_t, new_offset) = match &t {
                 Type::Struct {
@@ -194,7 +193,6 @@ impl Op {
             t = new_t;
             t_offset += new_offset;
         }
-        println!("    {:?}::{:?} total offset: {t_offset}", t, inner);
         (t, t_offset)
     }
 
@@ -531,7 +529,6 @@ impl Op {
 
                                 let size_delta = cast_type.size() - typ.size();
                                 self.kind = OpKind::Pad(size_delta);
-                                println!("Size delta: {size_delta}");
                             } else {
                                 compiler_error(
                                     &self.token,

--- a/src/ir/token.rs
+++ b/src/ir/token.rs
@@ -60,6 +60,7 @@ impl From<(LogosToken, &str)> for TokenKind {
             (LogosToken::ElseKeyword, _) => TokenKind::Keyword(Keyword::Else),
             (LogosToken::WhileKeyword, _) => TokenKind::Keyword(Keyword::While),
             (LogosToken::StructKeyword, _) => TokenKind::Keyword(Keyword::Struct),
+            (LogosToken::UnionKeyword, _) => TokenKind::Keyword(Keyword::Union),
             (LogosToken::CastKeyword, _) => TokenKind::Keyword(Keyword::Cast),
             (LogosToken::SplitKeyword, _) => TokenKind::Keyword(Keyword::Split),
             (LogosToken::SyscallKeyword, _) => TokenKind::Keyword(Keyword::Syscall),

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -38,6 +38,11 @@ pub enum Type {
         idents: Vec<String>,
         base: String,
     },
+    Union {
+        name: String,
+        members: Vec<Type>,
+        idents: Vec<String>,
+    },
 }
 
 impl Type {
@@ -57,6 +62,7 @@ impl Type {
             | Type::ResolvedStruct {
                 name: _, members, ..
             } => members.iter().map(|t| t.size()).sum(),
+            Type::Union { members, .. } => members.iter().map(|t| t.size()).max().unwrap(),
             Type::Placeholder { .. } => panic!("Size of Placeholder types are unknown: {:?}", self),
             Type::GenericStructBase { .. } => panic!("Size of a generic struct is unknown"),
             Type::GenericStructInstance { .. } => {
@@ -338,6 +344,9 @@ impl Type {
                 .as_str(),
                 vec![],
             ),
+            (Type::Union { .. }, _) => {
+                unimplemented!("{}: Resolving unions isn't implemented yet.", token.loc)
+            }
         };
 
         t
@@ -463,7 +472,9 @@ impl std::fmt::Debug for Type {
             Type::Bool => write!(f, "bool"),
             Type::Pointer { typ, .. } => write!(f, "*{:?}", *typ),
             Type::Placeholder { name } => write!(f, "{name}"),
-            Type::Struct { name, .. } | Type::ResolvedStruct { name, .. } => write!(f, "{name}"),
+            Type::Struct { name, .. }
+            | Type::ResolvedStruct { name, .. }
+            | Type::Union { name, .. } => write!(f, "{name}"),
             Type::GenericStructBase {
                 name,
                 members: _,

--- a/src/lex/logos_lex.rs
+++ b/src/lex/logos_lex.rs
@@ -43,6 +43,8 @@ pub enum LogosToken {
     WhileKeyword,
     #[token("struct")]
     StructKeyword,
+    #[token("union")]
+    UnionKeyword,
     #[token("cast")]
     CastKeyword,
     #[token("split")]

--- a/src/tests/union.hay
+++ b/src/tests/union.hay
@@ -1,0 +1,15 @@
+include "std.hay"
+union Foo {
+    u64: x
+    Str: s
+}
+
+fn main() {
+    69 cast(Foo) as [foo_u64]
+    "Hello World" cast(Foo) as [foo_str]
+    "Foo as u64: " puts foo_u64::x putlnu
+    "Bad::data: "  puts foo_u64::s::data cast(u64) putlnu
+    "Bad::size: "  puts foo_u64::s::size putlnu
+    "Foo as str: " puts foo_str::s putlns
+
+}

--- a/src/tests/union.try_com
+++ b/src/tests/union.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/union.asm\n[CMD]: ld -o union src/tests/union.o\n",
+  "stderr": ""
+}

--- a/src/tests/union.try_run
+++ b/src/tests/union.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "Foo as u64: 69\nBad::data: 0\nBad::size: 69\nFoo as str: Hello World\n",
+  "stderr": ""
+}


### PR DESCRIPTION
Adds support for unions

Closes #26 

## Summary

Unions allow for a single type to possibly represent many. For now, they must be concrete, and cannot support generic types.
The size of a union is the maximum size of any of it's members. You can currently only get a union's inner type after `as` binding it, using the same syntax as structs.

```
union Foo {
    u64: x
    Str: s
}

fn main() {
    69 cast(Foo) as [foo_u64]
    "Hello World" cast(Foo) as [foo_str]
    "Foo as u64: " puts foo_u64::x putlnu
    "Foo as str: " puts foo_str::s putlns
}
```
