### PR TITLE
Enums

### DIFF
--- a/examples/enum.hay
+++ b/examples/enum.hay
@@ -6,7 +6,7 @@ enum Foo {
 }
 
 fn main() {
-    Foo::x Foo::y == if {
+    Foo::x Foo::z == if {
         "Enums match!" putlns
     } else {
         "Enums don't match" putlns

--- a/examples/enum.hay
+++ b/examples/enum.hay
@@ -1,0 +1,14 @@
+include "std.hay"
+enum Foo {
+    x
+    y
+    z
+}
+
+fn main() {
+    Foo::x Foo::y == if {
+        "Enums match!" putlns
+    } else {
+        "Enums don't match" putlns
+    }
+}

--- a/src/compiler/x86_64.rs
+++ b/src/compiler/x86_64.rs
@@ -70,6 +70,10 @@ fn compile_op(
             writeln!(file, "  push {str_len}").unwrap();
             writeln!(file, "  push {str_ident}").unwrap();
         }
+        OpKind::PushEnum { .. } => unreachable!(
+            "{}: {:?} should have been converted into PushInt by now...",
+            op.token.loc, op.kind
+        ),
         OpKind::Add => {
             writeln!(file, "  pop  rbx").unwrap();
             writeln!(file, "  pop  rax").unwrap();

--- a/src/ir/keyword.rs
+++ b/src/ir/keyword.rs
@@ -10,6 +10,7 @@ pub enum Keyword {
     While,
     Struct,
     Union,
+    Enum,
     Cast,
     Split,
     Syscall,

--- a/src/ir/program.rs
+++ b/src/ir/program.rs
@@ -208,6 +208,44 @@ impl Program {
                                 index: *idx,
                                 inner: fields.clone(),
                             };
+                        } else if self.types.contains_key(s) {
+                            if let Type::Enum { name, variants } = self.types.get(s).unwrap() {
+                                if fields.is_empty() {
+                                    compiler_error(
+                                        &op.token,
+                                        "Expected enum variant, but found nothing.",
+                                        vec![format!("{name} variants: {:?}", variants).as_str()],
+                                    );
+                                } else if fields.len() != 1 {
+                                    compiler_error(
+                                        &op.token,
+                                        format!("Unexpected fields {:?}", &fields[1..]).as_str(),
+                                        vec![],
+                                    );
+                                }
+
+                                if let Some(idx) = variants.iter().position(|v| v == &fields[0]) {
+                                    op.kind = OpKind::PushEnum {
+                                        typ: self.types.get(s).unwrap().clone(),
+                                        idx,
+                                    };
+                                } else {
+                                    compiler_error(
+                                        &op.token,
+                                        format!("Unrecognized variant for enum {name}").as_str(),
+                                        vec![
+                                            format!("Expected one of: {:?}", variants).as_str(),
+                                            format!("Found: {}", fields[0]).as_str(),
+                                        ],
+                                    );
+                                }
+                            } else {
+                                compiler_error(
+                                    &op.token,
+                                    format!("Unrecognized Identifier: `{s}`").as_str(),
+                                    vec![],
+                                )
+                            }
                         } else {
                             compiler_error(
                                 &op.token,

--- a/src/ir/token.rs
+++ b/src/ir/token.rs
@@ -61,6 +61,7 @@ impl From<(LogosToken, &str)> for TokenKind {
             (LogosToken::WhileKeyword, _) => TokenKind::Keyword(Keyword::While),
             (LogosToken::StructKeyword, _) => TokenKind::Keyword(Keyword::Struct),
             (LogosToken::UnionKeyword, _) => TokenKind::Keyword(Keyword::Union),
+            (LogosToken::EnumKeyword, _) => TokenKind::Keyword(Keyword::Enum),
             (LogosToken::CastKeyword, _) => TokenKind::Keyword(Keyword::Cast),
             (LogosToken::SplitKeyword, _) => TokenKind::Keyword(Keyword::Split),
             (LogosToken::SyscallKeyword, _) => TokenKind::Keyword(Keyword::Syscall),

--- a/src/lex/logos_lex.rs
+++ b/src/lex/logos_lex.rs
@@ -45,6 +45,8 @@ pub enum LogosToken {
     StructKeyword,
     #[token("union")]
     UnionKeyword,
+    #[token("enum")]
+    EnumKeyword,
     #[token("cast")]
     CastKeyword,
     #[token("split")]

--- a/src/tests/enum.hay
+++ b/src/tests/enum.hay
@@ -1,0 +1,14 @@
+include "std.hay"
+enum Foo {
+    x
+    y
+    z
+}
+
+fn main() {
+    Foo::x Foo::z == if {
+        "Enums match!" putlns
+    } else {
+        "Enums don't match" putlns
+    }
+}

--- a/src/tests/enum.try_com
+++ b/src/tests/enum.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/enum.asm\n[CMD]: ld -o enum src/tests/enum.o\n",
+  "stderr": ""
+}

--- a/src/tests/enum.try_run
+++ b/src/tests/enum.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "Enums don't match\n",
+  "stderr": ""
+}


### PR DESCRIPTION
Adds basic support for enums

```
include "std.hay"
enum Foo {
    x
    y
    z
}

fn main() {
    Foo::x Foo::z == if {
        "Enums match!" putlns
    } else {
        "Enums don't match" putlns
    }
}
```
