### PR TITLE
Struct Visibility

### DIFF
--- a/examples/impl.hay
+++ b/examples/impl.hay
@@ -1,0 +1,15 @@
+include "std.hay"
+
+struct Foo<T> {
+    T: bar
+
+impl:
+    fn get_bar<T>(Foo<T>: foo) -> [T] { foo::bar }    
+}
+
+fn main() {
+
+    "Private Field" cast(Foo) get_bar putlns
+    12345           cast(Foo) get_bar putlnu
+
+}

--- a/src/compiler/common.rs
+++ b/src/compiler/common.rs
@@ -13,20 +13,35 @@ pub fn simplify_ir<P: AsRef<std::path::Path> + std::clone::Clone>(program: &Prog
         writeln!(&mut file, "{t}").unwrap();
         match t {
             Type::GenericStructBase {
-                members, idents, ..
+                members,
+                idents,
+                visibility,
+                ..
             }
             | Type::Struct {
-                members, idents, ..
+                members,
+                idents,
+                visibility,
+                ..
             }
             | Type::GenericStructInstance {
-                members, idents, ..
+                members,
+                idents,
+                visibility,
+                ..
             }
             | Type::ResolvedStruct {
-                members, idents, ..
+                members,
+                idents,
+                visibility,
+                ..
             } => members
                 .iter()
                 .zip(idents)
-                .for_each(|(t, ident)| writeln!(&mut file, " -- {:?}: {ident}", t).unwrap()),
+                .zip(visibility)
+                .for_each(|((t, ident), vis)| {
+                    writeln!(&mut file, " -- {:?} {:?}: {ident}", vis, t).unwrap()
+                }),
             _ => (),
         }
     });

--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -25,6 +25,7 @@ pub struct Function {
     pub ops: Vec<Op>,
     pub generics_map: HashMap<String, TypeName>,
     pub locals: BTreeMap<String, LocalVar>,
+    pub type_visibility: Option<TypeName>,
 }
 
 impl Function {
@@ -72,6 +73,7 @@ impl Function {
             &self.locals,
             globals,
             vec![],
+            &self.type_visibility,
         );
         self.check_output(&stack);
 
@@ -204,6 +206,7 @@ impl Function {
             ops: new_ops,
             generics_map,
             locals: self.locals.clone(),
+            type_visibility: self.type_visibility.clone(),
         }
     }
 
@@ -290,6 +293,7 @@ impl Function {
             ops: new_ops,
             generics_map: map,
             locals: self.locals.clone(),
+            type_visibility: self.type_visibility.clone(),
         }
     }
 }

--- a/src/ir/keyword.rs
+++ b/src/ir/keyword.rs
@@ -15,4 +15,5 @@ pub enum Keyword {
     Syscall,
     Include,
     SizeOf,
+    Pub,
 }

--- a/src/ir/keyword.rs
+++ b/src/ir/keyword.rs
@@ -16,4 +16,5 @@ pub enum Keyword {
     Include,
     SizeOf,
     Pub,
+    Impl,
 }

--- a/src/ir/op.rs
+++ b/src/ir/op.rs
@@ -134,11 +134,13 @@ impl Op {
                 Type::Struct {
                     name,
                     ref members,
+                    visibility: _,
                     ref idents,
                 }
                 | Type::ResolvedStruct {
                     name,
                     ref members,
+                    visibility: _,
                     ref idents,
                     ..
                 } => {
@@ -172,11 +174,13 @@ impl Op {
                 Type::Union {
                     name,
                     ref members,
+                    visibility: _,
                     ref idents,
                 }
                 | Type::ResolvedUnion {
                     name,
                     ref members,
+                    visibility: _,
                     ref idents,
                     ..
                 } => {

--- a/src/ir/token.rs
+++ b/src/ir/token.rs
@@ -67,6 +67,7 @@ impl From<(LogosToken, &str)> for TokenKind {
             (LogosToken::IncludeKeyword, _) => TokenKind::Keyword(Keyword::Include),
             (LogosToken::SizeOfKeyword, _) => TokenKind::Keyword(Keyword::SizeOf),
             (LogosToken::PubKeyword, _) => TokenKind::Keyword(Keyword::Pub),
+            (LogosToken::ImplKeyword, _) => TokenKind::Keyword(Keyword::Impl),
             // Markers
             (LogosToken::OpenBrace, _) => TokenKind::Marker(Marker::OpenBrace),
             (LogosToken::CloseBrace, _) => TokenKind::Marker(Marker::CloseBrace),

--- a/src/ir/token.rs
+++ b/src/ir/token.rs
@@ -66,6 +66,7 @@ impl From<(LogosToken, &str)> for TokenKind {
             (LogosToken::SyscallKeyword, _) => TokenKind::Keyword(Keyword::Syscall),
             (LogosToken::IncludeKeyword, _) => TokenKind::Keyword(Keyword::Include),
             (LogosToken::SizeOfKeyword, _) => TokenKind::Keyword(Keyword::SizeOf),
+            (LogosToken::PubKeyword, _) => TokenKind::Keyword(Keyword::Pub),
             // Markers
             (LogosToken::OpenBrace, _) => TokenKind::Marker(Marker::OpenBrace),
             (LogosToken::CloseBrace, _) => TokenKind::Marker(Marker::CloseBrace),

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 pub type TypeName = String;
 
-#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash, Debug)]
 pub enum Visibility {
     Public,
     Private,

--- a/src/ir/types.rs
+++ b/src/ir/types.rs
@@ -5,6 +5,12 @@ use std::collections::{HashMap, HashSet};
 pub type TypeName = String;
 
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
+pub enum Visibility {
+    Public,
+    Private,
+}
+
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Hash)]
 pub enum Type {
     U64,
     U8,
@@ -22,17 +28,20 @@ pub enum Type {
     Struct {
         name: TypeName,
         members: Vec<TypeName>,
+        visibility: Vec<Visibility>,
         idents: Vec<String>,
     },
     GenericStructBase {
         name: TypeName,
         members: Vec<TypeName>,
+        visibility: Vec<Visibility>,
         idents: Vec<String>,
         generics: Vec<TypeName>,
     },
     GenericStructInstance {
         base: TypeName,
         members: Vec<TypeName>,
+        visibility: Vec<Visibility>,
         idents: Vec<String>,
         alias_list: Vec<TypeName>,
         base_generics: Vec<TypeName>,
@@ -40,23 +49,27 @@ pub enum Type {
     ResolvedStruct {
         name: TypeName,
         members: Vec<TypeName>,
+        visibility: Vec<Visibility>,
         idents: Vec<String>,
         base: TypeName,
     },
     Union {
         name: TypeName,
         members: Vec<TypeName>,
+        visibility: Vec<Visibility>,
         idents: Vec<String>,
     },
     GenericUnionBase {
         name: TypeName,
         members: Vec<TypeName>,
+        visibility: Vec<Visibility>,
         idents: Vec<String>,
         generics: Vec<TypeName>,
     },
     GenericUnionInstance {
         base: TypeName,
         members: Vec<TypeName>,
+        visibility: Vec<Visibility>,
         idents: Vec<String>,
         alias_list: Vec<TypeName>,
         base_generics: Vec<TypeName>,
@@ -64,6 +77,7 @@ pub enum Type {
     ResolvedUnion {
         name: TypeName,
         members: Vec<TypeName>,
+        visibility: Vec<Visibility>,
         idents: Vec<String>,
         base: TypeName,
     },
@@ -218,6 +232,7 @@ impl Type {
                 }
                 .name(),
             ],
+            visibility: vec![Visibility::Public, Visibility::Public],
             idents: vec![String::from("size"), String::from("data")],
         }
     }
@@ -235,6 +250,7 @@ impl Type {
                 }
                 .name(),
             ],
+            visibility: vec![Visibility::Public, Visibility::Public],
             idents: vec![String::from("size"), String::from("data")],
             generics: vec![String::from("T")],
         }
@@ -246,10 +262,11 @@ impl Type {
         stack: &Stack,
         type_map: &mut HashMap<TypeName, Type>,
     ) -> TypeName {
-        let (pairs, base, idents, generics) = match type_map.get(gen_struct_t).unwrap().clone() {
+        let (pairs, base, visibility, idents, generics) = match type_map.get(gen_struct_t).unwrap().clone() {
             Type::GenericStructBase {
                 name,
                 members,
+                visibility,
                 idents,
                 generics,
             } => {
@@ -258,7 +275,7 @@ impl Type {
                     .zip(stack[stack.len() - members.len()..].iter())
                     .map(|(t1, t2)| (t1.clone(), t2.clone()))
                     .collect();
-                (pairs, name, idents.clone(), generics.clone())
+                (pairs, name, visibility, idents.clone(), generics.clone())
             }
             _ => panic!("Resolve struct should only be run on Base Generic Structs...\n{}: Type: {:?} Stack: {:?}", token.loc, gen_struct_t, stack),
         };
@@ -309,6 +326,7 @@ impl Type {
         let t = Type::ResolvedStruct {
             name,
             members: resolved_members,
+            visibility,
             idents,
             base: base.clone(),
         };
@@ -399,6 +417,7 @@ impl Type {
                 Type::GenericStructInstance {
                     base: instance_base,
                     members,
+                    visibility: _,
                     idents: _,
                     alias_list,
                     base_generics,
@@ -406,6 +425,7 @@ impl Type {
                 Type::ResolvedStruct {
                     name: _,
                     members: resolved_members,
+                    visibility: _,
                     idents: _,
                     base: resolved_base,
                 },
@@ -603,6 +623,7 @@ impl Type {
             Type::GenericUnionInstance {
                 base,
                 members,
+                visibility,
                 idents,
                 alias_list,
                 base_generics,
@@ -610,6 +631,7 @@ impl Type {
             | Type::GenericStructInstance {
                 base,
                 members,
+                visibility,
                 idents,
                 alias_list,
                 base_generics,
@@ -670,6 +692,7 @@ impl Type {
                     Type::ResolvedStruct {
                         name,
                         members: resolved_members,
+                        visibility: visibility.clone(),
                         idents: idents.clone(),
                         base: base.clone(),
                     }
@@ -680,6 +703,7 @@ impl Type {
                     Type::ResolvedUnion {
                         name,
                         members: resolved_members,
+                        visibility: visibility.clone(),
                         idents: idents.clone(),
                         base: base.clone(),
                     }
@@ -693,12 +717,14 @@ impl Type {
             Type::GenericUnionBase {
                 name: base,
                 members,
+                visibility,
                 idents,
                 generics,
             }
             | Type::GenericStructBase {
                 name: base,
                 members,
+                visibility,
                 idents,
                 generics,
             } => {
@@ -727,6 +753,7 @@ impl Type {
                     Type::ResolvedStruct {
                         name,
                         members: resolved_members,
+                        visibility: visibility.clone(),
                         idents: idents.clone(),
                         base: base.clone(),
                     }
@@ -734,6 +761,7 @@ impl Type {
                     Type::ResolvedUnion {
                         name,
                         members: resolved_members,
+                        visibility: visibility.clone(),
                         idents: idents.clone(),
                         base: base.clone(),
                     }
@@ -777,6 +805,7 @@ impl Type {
                 Type::GenericUnionBase {
                     name,
                     members,
+                    visibility,
                     idents,
                     generics,
                 },
@@ -799,6 +828,7 @@ impl Type {
                     let t = Type::GenericUnionInstance {
                         base: name.clone(),
                         members: members.clone(),
+                        visibility: visibility.clone(),
                         idents: idents.clone(),
                         alias_list: annotations.to_vec(),
                         base_generics: generics.clone(),
@@ -824,6 +854,7 @@ impl Type {
                 Type::GenericStructBase {
                     name,
                     members,
+                    visibility,
                     idents,
                     generics,
                 },
@@ -846,6 +877,7 @@ impl Type {
                     let t = Type::GenericStructInstance {
                         base: name.clone(),
                         members: members.clone(),
+                        visibility: visibility.clone(),
                         idents: idents.clone(),
                         alias_list: annotations.to_vec(),
                         base_generics: generics.clone(),

--- a/src/lex/lexer.rs
+++ b/src/lex/lexer.rs
@@ -9,7 +9,7 @@ use crate::ir::{
     operator::Operator,
     program::Program,
     token::{Loc, Token, TokenKind},
-    types::{Signature, Type, TypeName},
+    types::{Signature, Type, TypeName, Visibility},
 };
 use crate::lex::logos_lex::{into_token, LogosToken};
 use logos::Logos;
@@ -328,6 +328,7 @@ fn parse_type(
         Some(Type::GenericStructBase {
             name: base,
             members,
+            visibility,
             idents,
             generics,
         }) => {
@@ -358,6 +359,7 @@ fn parse_type(
                 let t = Type::GenericStructInstance {
                     base: name.clone(),
                     members: members.clone(),
+                    visibility: visibility.clone(),
                     idents: idents.clone(),
                     alias_list: annotations,
                     base_generics: generics.clone(),
@@ -377,6 +379,7 @@ fn parse_type(
         Some(Type::GenericUnionBase {
             name: base,
             members,
+            visibility,
             idents,
             generics,
         }) => {
@@ -407,6 +410,7 @@ fn parse_type(
                 let t = Type::GenericUnionInstance {
                     base: name.clone(),
                     members: members.clone(),
+                    visibility: visibility.clone(),
                     idents: idents.clone(),
                     alias_list: annotations,
                     base_generics: generics.clone(),
@@ -1112,6 +1116,7 @@ fn parse_union(
     let (tok, generics) = parse_annotation_list(&name_tok, tokens, type_map);
     let tok = expect_token_kind(&tok, tokens, TokenKind::Marker(Marker::OpenBrace));
     let (members, idents) = parse_tagged_type_list(&tok, tokens, type_map, &generics);
+    let n_members = members.len();
     let _tok = expect_token_kind(&name_tok, tokens, TokenKind::Marker(Marker::CloseBrace));
 
     if let Some(generics) = generics {
@@ -1120,6 +1125,7 @@ fn parse_union(
             Type::GenericUnionBase {
                 name,
                 members,
+                visibility: (0..n_members).map(|_| Visibility::Private).collect(),
                 idents,
                 generics,
             },
@@ -1130,6 +1136,7 @@ fn parse_union(
             Type::Union {
                 name,
                 members,
+                visibility: (0..n_members).map(|_| Visibility::Private).collect(),
                 idents,
             },
         )
@@ -1150,6 +1157,7 @@ fn parse_struct(
             Type::GenericStructBase {
                 name: name.clone(),
                 members: vec![],
+                visibility: vec![],
                 idents: vec![],
                 generics: vec![],
             }
@@ -1157,6 +1165,7 @@ fn parse_struct(
             Type::Struct {
                 name: name.clone(),
                 members: vec![],
+                visibility: vec![],
                 idents: vec![],
             }
         },
@@ -1169,6 +1178,7 @@ fn parse_struct(
     }
     let tok = expect_token_kind(&tok, tokens, TokenKind::Marker(Marker::OpenBrace));
     let (members, idents) = parse_tagged_type_list(&tok, tokens, type_map, &generics);
+    let n_members = members.len();
     let _tok = expect_token_kind(&name_tok, tokens, TokenKind::Marker(Marker::CloseBrace));
 
     if let Some(gen) = generics {
@@ -1178,6 +1188,7 @@ fn parse_struct(
             Type::GenericStructBase {
                 name,
                 members,
+                visibility: (0..n_members).map(|_| Visibility::Private).collect(),
                 idents,
                 generics: gen,
             },
@@ -1189,6 +1200,7 @@ fn parse_struct(
             Type::Struct {
                 name,
                 members,
+                visibility: (0..n_members).map(|_| Visibility::Private).collect(),
                 idents,
             },
         )

--- a/src/lex/logos_lex.rs
+++ b/src/lex/logos_lex.rs
@@ -57,6 +57,8 @@ pub enum LogosToken {
     SizeOfKeyword,
     #[token("pub")]
     PubKeyword,
+    #[token("impl")]
+    ImplKeyword,
 
     // Markers
     #[token("{")]

--- a/src/lex/logos_lex.rs
+++ b/src/lex/logos_lex.rs
@@ -55,6 +55,8 @@ pub enum LogosToken {
     IncludeKeyword,
     #[token("sizeOf")]
     SizeOfKeyword,
+    #[token("pub")]
+    PubKeyword,
 
     // Markers
     #[token("{")]

--- a/src/libs/alloc.hay
+++ b/src/libs/alloc.hay
@@ -4,14 +4,14 @@ include "sys_x86_64.hay"
 
 // Doesn't need to be aligned to page size
 struct Block {
-    Arr<u8>: arr
-    bool: allocated
+    pub Arr<u8>: arr
+    pub bool: allocated
 }
 
 // Always aligned to page size
 struct Chunk {
-    u64: cap
-    *Block: start
+    pub u64: cap
+    pub *Block: start
 }
 
 fn Chunk.next(*Block: blk_p) -> [*Block] {

--- a/src/libs/file.hay
+++ b/src/libs/file.hay
@@ -2,7 +2,7 @@ include "str.hay"
 include "alloc.hay"
 
 struct File {
-    u64: fd
+    pub u64: fd
 }
 
 fn File.exists(Str: file_name) -> [bool] {

--- a/src/libs/linear_map.hay
+++ b/src/libs/linear_map.hay
@@ -5,108 +5,109 @@ include "opt.hay"
 struct Map<T> {
     *Stack<Str>: keys
     *Stack<T>: values
-}
 
-fn Map.new<T>() -> [*Map<T>] {
-    malloc_obj::<Map<T>> as [map_p]
-    map_p Map.init
-    map_p
-}
+impl:
+    fn Map.new<T>() -> [*Map<T>] {
+        malloc_obj::<Map<T>> as [map_p]
+        map_p Map.init
+        map_p
+    }
 
-fn Map.init<T>(*Map<T>: map_p) {
-    malloc_obj::<Stack<Str>> as [keys_p]
-    malloc_obj::<Stack<T>> as [values_p] 
+    fn Map.init<T>(*Map<T>: map_p) {
+        malloc_obj::<Stack<Str>> as [keys_p]
+        malloc_obj::<Stack<T>> as [values_p] 
+        
+        keys_p   Stack.init
+        values_p Stack.init
+        keys_p values_p cast(Map) map_p !
+    }
+
+    fn Map.destroy<T>(*Map<T>: map_p) {
+        map_p @ as [map]
+        map::keys   Stack.destroy
+        map::values Stack.destroy
+        map::keys   free_obj
+        map::values free_obj
+    }
+
+    fn Map.idx_of<T>(Str: key *Map<T>: map_p) -> [Opt<u64>] {
     
-    keys_p   Stack.init
-    values_p Stack.init
-    keys_p values_p cast(Map) map_p !
-}
-
-fn Map.destroy<T>(*Map<T>: map_p) {
-    map_p @ as [map]
-    map::keys   Stack.destroy
-    map::values Stack.destroy
-    map::keys   free_obj
-    map::values free_obj
-}
-
-fn Map.idx_of<T>(Str: key *Map<T>: map_p) -> [Opt<u64>] {
-
-    map_p @ as [map]
-    map::keys @ as [keys]
-    false 0 while as [result idx] { result idx
-        result lnot
-        idx keys::len < land
-    } {
-        as [result idx]
-        idx keys::slice Arr.get key Str.equals 
-        idx 1 + 
+        map_p @ as [map]
+        false 0 while as [result idx] { result idx
+            result lnot
+            idx map::keys Stack.len < land
+        } {
+            as [result idx]
+            idx map::keys Stack.get Opt.unwrap key Str.equals 
+            idx 1 + 
+        }
+    
+        as [result idx] 
+    
+        result if {
+            idx 1 - Opt.Some
+        } else {
+            Opt.None::<u64>
+        }
+    
     }
 
-    as [result idx] 
-
-    result if {
-        idx 1 - Opt.Some
-    } else {
-        Opt.None::<u64>
+    fn Map.contains<T>(Str: key *Map<T>: map_p) -> [bool] {
+        key map_p Map.idx_of Opt.is_some
     }
 
-}
-
-fn Map.contains<T>(Str: key *Map<T>: map_p) -> [bool] {
-    key map_p Map.idx_of Opt.is_some
-}
-
-fn Map.get_ref<T>(Str: key *Map<T>: map_p) -> [Opt<*T>] {
-    map_p @ as [map]
-    map::values @ as [values]
-    key map_p Map.idx_of as [maybe_idx] 
-    maybe_idx Opt.is_some if {
-        maybe_idx Opt.unwrap values::slice Arr.get_ref Opt.Some
-    } else {
-        Opt.None::<*T>
-    }
-}
-
-fn Map.get<T>(Str: key *Map<T>: map_p) -> [Opt<T>] {
-    map_p @ as [map]
-    map::values @ as [values]
-    key map_p Map.idx_of as [maybe_idx] 
-    maybe_idx Opt.is_some if {
-        maybe_idx Opt.unwrap values::slice Arr.get Opt.Some
-    } else {
-        Opt.None::<T>
+    fn Map.get_ref<T>(Str: key *Map<T>: map_p) -> [Opt<*T>] {
+        map_p @ as [map]
+        map::values @ as [values]
+        key map_p Map.idx_of as [maybe_idx] 
+        maybe_idx Opt.is_some if {
+            maybe_idx Opt.unwrap values::slice Arr.get_ref Opt.Some
+        } else {
+            Opt.None::<*T>
+        }
     }
 
-}
+    fn Map.get<T>(Str: key *Map<T>: map_p) -> [Opt<T>] {
+        map_p @ as [map]
+        key map_p Map.idx_of as [maybe_idx] 
+        maybe_idx Opt.is_some if {
+            maybe_idx Opt.unwrap map::values Stack.get
+        } else {
+            Opt.None::<T>
+        }
 
-fn Map.insert<T>(Str: key T: value *Map<T>: map_p) -> [Opt<T>] {
-    map_p @ as [map]
-    map::keys @ map::values @ as [keys values]
-
-    key map_p Map.idx_of as [maybe_idx]
-    maybe_idx Opt.is_some if {
-        maybe_idx Opt.unwrap as [idx]
-        idx values::slice Arr.get Opt.Some
-        value idx values::slice Arr.set
-    } else {
-        key map::keys Stack.push
-        value map::values Stack.push
-        Opt.None::<T>
     }
 
+    fn Map.insert<T>(Str: key T: value *Map<T>: map_p) -> [Opt<T>] {
+        map_p @ as [map]
+        
+        key map_p Map.idx_of as [maybe_idx]
+        maybe_idx Opt.is_some if {
+            maybe_idx Opt.unwrap as [idx]
+            idx map::values Stack.get
+            value idx map::values Stack.set
+        } else {
+            key map::keys Stack.push
+            value map::values Stack.push
+            Opt.None::<T>
+        }
+
+    }
+
+    fn Map.reverse_lookup<T>(*T: value_p *Map<T>: map_p) -> [Str] {
+        map_p @ as [map]
+        map::keys @ map::values @ as [keys values]
+        keys::arr::data                     // Linear map is two stacks
+        value_p values::arr::data ptr-diff  // Find the index of the type in the values
+        ptr+ @                              // Offset to the same key and read
+    }
+
+    fn Map.len<T>(*Map<T>: map_p) -> [u64] {
+        map_p @ as [map]
+        map::keys @ as [keys]
+        keys::len
+    }
+
+
 }
 
-fn Map.reverse_lookup<T>(*T: value_p *Map<T>: map_p) -> [Str] {
-    map_p @ as [map]
-    map::keys @ map::values @ as [keys values]
-    keys::arr::data                     // Linear map is two stacks
-    value_p values::arr::data ptr-diff  // Find the index of the type in the values
-    ptr+ @                              // Offset to the same key and read
-}
-
-fn Map.len<T>(*Map<T>: map_p) -> [u64] {
-    map_p @ as [map]
-    map::keys @ as [keys]
-    keys::len
-}

--- a/src/libs/opt.hay
+++ b/src/libs/opt.hay
@@ -12,35 +12,40 @@ union OptVal<T> {
 struct Opt<T> {
     OptVal<T>: value
     OptTag: tag
-}
 
-fn Opt.Some<T>(T) -> [Opt<T>] {
-    cast(OptVal<T>)
-    OptTag::Some
-    cast(Opt)
-}
+impl:
 
-fn Opt.None<T>() -> [Opt<T>] {
-    0 cast(OptVal<T>)
-    OptTag::None
-    cast(Opt)
-}
-
-fn Opt.is_some<T>(Opt<T>: opt) -> [bool] {
-    opt::tag OptTag::Some ==
-}
-
-fn Opt.is_none<T>(Opt<T>: opt) -> [bool] {
-    opt::tag OptTag::None ==
-}
-
-fn Opt.unwrap<T>(Opt<T>: opt) -> [T] {
-
-    opt Opt.is_none if {
-        "Unwrapped a None variant" putlns
-        1 exit 
+    fn Opt.Some<T>(T) -> [Opt<T>] {
+        cast(OptVal<T>)
+        OptTag::Some
+        cast(Opt)
     }
 
-    opt::value::Some
+    fn Opt.None<T>() -> [Opt<T>] {
+        0 cast(OptVal<T>)
+        OptTag::None
+        cast(Opt)
+    }
+
+    fn Opt.is_some<T>(Opt<T>: opt) -> [bool] {
+        opt::tag OptTag::Some ==
+    }
+
+    fn Opt.is_none<T>(Opt<T>: opt) -> [bool] {
+        opt::tag OptTag::None ==
+    }
+
+    fn Opt.unwrap<T>(Opt<T>: opt) -> [T] {
+
+        opt Opt.is_none if {
+            "Unwrapped a None variant" putlns
+            1 exit 
+        }
+
+        opt::value::Some
+
+    }
+
 
 }
+

--- a/src/libs/stack.hay
+++ b/src/libs/stack.hay
@@ -4,99 +4,116 @@ include "alloc.hay"
 
 struct Stack<T> {
     Arr<T>: slice
-    u64: len
-}
+    pub u64: len
 
-fn Stack.new<T>() -> [*Stack<T>] {
-    malloc_obj::<Stack<T>> as [stk_p]
-    stk_p Stack.init
-    stk_p
-}
-
-fn Stack.slice<T>(*Stack<T>: stk_p) -> [Arr<T>] {
-    stk_p @ as [stk]
-    stk::len stk::slice::data cast(Arr)
-}
-
-fn Stack.init<T>(*Stack<T>: stk_p) {
-    8 malloc::<T> 0 cast(Stack) stk_p !
-}
-
-fn Stack.push<T>(T: value *Stack<T>: stk_p) {
-    stk_p @ as [stk] {
-        stk::len stk::slice::size == if {
-            stk::slice::size 2 * stk::slice realloc stk::len cast(Stack) stk_p !  
-        }    
+impl:
+    fn Stack.new<T>() -> [*Stack<T>] {
+        malloc_obj::<Stack<T>> as [stk_p]
+        stk_p Stack.init
+        stk_p
     }
 
-    stk_p @ as [stk]
-    {
-        value stk::len stk::slice Arr.set
-        stk::slice stk::len 1 + cast(Stack) stk_p !
+    fn Stack.slice<T>(*Stack<T>: stk_p) -> [Arr<T>] {
+        stk_p @ as [stk]
+        stk::len stk::slice::data cast(Arr)
     }
-}
 
-fn Stack.pop<T>(*Stack<T>: stk_p) -> [Opt<T>] {
-    stk_p @ as [stk]
-    stk::len 0 == if {
-        Opt.None::<T>
-    } else {
-        stk::slice stk::len 1 - cast(Stack) stk_p !
-        stk::len 1 - stk::slice Arr.get Opt.Some
+    fn Stack.init<T>(*Stack<T>: stk_p) {
+        8 malloc::<T> 0 cast(Stack) stk_p !
     }
-}
 
-fn Stack.peek<T>(*Stack<T>: stk_p) -> [Opt<T>] {
-    stk_p @ as [stk]
-    stk::len 0 == if {
-        Opt.None::<T>
-    } else {
-        stk::len 1 - stk::slice Arr.get Opt.Some
-    }
-}
-
-fn Stack.rev<T>(*Stack<T>: stk_p) {
-    stk_p @ as [stk]
-    stk::len stk::slice::data cast(Arr) Arr.rev
-}
-
-fn Stack.destroy<T>(*Stack<T>: stk_p) {
-    stk_p @ as [stk]
-    stk::slice free
-}
-
-fn Stack.is_empty<T>(*Stack<T>: stk_p) -> [bool] {
-    stk_p @ as [stk]
-    stk::len 0 == 
-}
-
-fn Stack.len<T>(*Stack<T>: stk_p) -> [u64] {
-    stk_p @ as [stk]
-    stk::len
-}
-
-// Note this will only work for types which can be converted to u64
-fn Stack.find<T>(T: t *Stack<T>: stk_p) -> [Opt<u64>] {
-
-    var Opt<u64>: idx
-    Opt.None::<u64> idx ! 
-
-    stk_p @ as [stk]
-    false 0 while as [break i]{ break i
-        break lnot
-        i stk::len < land
-    }{
-        as [_ i]
-        i stk::slice Arr.get cast(u64) t cast(u64) == if {
-            i Opt.Some idx !
-            true
-        } else {
-            false
+    fn Stack.push<T>(T: value *Stack<T>: stk_p) {
+        stk_p @ as [stk] {
+            stk::len stk::slice::size == if {
+                stk::slice::size 2 * stk::slice realloc stk::len cast(Stack) stk_p !  
+            }    
         }
+
+        stk_p @ as [stk]
+        {
+            value stk::len stk::slice Arr.set
+            stk::slice stk::len 1 + cast(Stack) stk_p !
+        }
+    }
+
+    fn Stack.pop<T>(*Stack<T>: stk_p) -> [Opt<T>] {
+        stk_p @ as [stk]
+        stk::len 0 == if {
+            Opt.None::<T>
+        } else {
+            stk::slice stk::len 1 - cast(Stack) stk_p !
+            stk::len 1 - stk::slice Arr.get Opt.Some
+        }
+    }
+
+    fn Stack.peek<T>(*Stack<T>: stk_p) -> [Opt<T>] {
+        stk_p @ as [stk]
+        stk::len 0 == if {
+            Opt.None::<T>
+        } else {
+            stk::len 1 - stk::slice Arr.get Opt.Some
+        }
+    }
+
+    fn Stack.rev<T>(*Stack<T>: stk_p) {
+        stk_p @ as [stk]
+        stk::len stk::slice::data cast(Arr) Arr.rev
+    }
+
+    fn Stack.destroy<T>(*Stack<T>: stk_p) {
+        stk_p @ as [stk]
+        stk::slice free
+    }
+
+    fn Stack.is_empty<T>(*Stack<T>: stk_p) -> [bool] {
+        stk_p @ as [stk]
+        stk::len 0 == 
+    }
+
+    fn Stack.len<T>(*Stack<T>: stk_p) -> [u64] {
+        stk_p @ as [stk]
+        stk::len
+    }
+
+    // Note this will only work for types which can be converted to u64
+    fn Stack.find<T>(T: t *Stack<T>: stk_p) -> [Opt<u64>] {
+
+        var Opt<u64>: idx
+        Opt.None::<u64> idx ! 
+
+        stk_p @ as [stk]
+        false 0 while as [break i]{ break i
+            break lnot
+            i stk::len < land
+        }{
+            as [_ i]
+            i stk::slice Arr.get cast(u64) t cast(u64) == if {
+                i Opt.Some idx !
+                true
+            } else {
+                false
+            }
+            
+            i 1 +
+        } drop drop
+
+        idx @ 
+
+    }
+
+    fn Stack.get<T>(u64: idx *Stack<T>: stk_p) -> [Opt<T>] {
+        stk_p @ as [stk]
         
-        i 1 +
-    } drop drop
+        idx stk::len < if {
+            idx stk::slice Arr.get Opt.Some
+        } else {
+            Opt.None::<T>
+        }
+    }
 
-     idx @ 
-
+    fn Stack.set<T>(T: value u64: idx *Stack<T>: stk_p) {
+        stk_p @ as [stk]
+        value idx stk::slice Arr.set
+    }
 }
+

--- a/src/libs/str.hay
+++ b/src/libs/str.hay
@@ -1,7 +1,7 @@
 include "sys_x86_64.hay"
 struct cStr {
-    u64: size
-    *u8: data
+    pub u64: size
+    pub *u8: data
 }
 
 fn cStr.to_Str(cStr: cs) -> [Str] {

--- a/src/tests/generic_struct.hay
+++ b/src/tests/generic_struct.hay
@@ -1,17 +1,17 @@
 include "std.hay"
 
 struct Foo {
-    u64: bar
+    pub u64: bar
 }
 
 struct Pair<T> {
-    T: first 
-    T: second
+    pub T: first 
+    pub T: second
 }
 
 struct Quad<A B> {
-    Pair<A>: a
-    Pair<B>: b
+    pub Pair<A>: a
+    pub Pair<B>: b
 }
 
 fn into_quad<A B>(Pair<A>: a Pair<B>: b) -> [Quad<A B>] {

--- a/src/tests/impl.hay
+++ b/src/tests/impl.hay
@@ -1,0 +1,15 @@
+include "std.hay"
+
+struct Foo<T> {
+    T: bar
+
+impl:
+    fn get_bar<T>(Foo<T>: foo) -> [T] { foo::bar }    
+}
+
+fn main() {
+
+    "Private Field" cast(Foo) get_bar putlns
+    12345           cast(Foo) get_bar putlnu
+
+}

--- a/src/tests/impl.try_com
+++ b/src/tests/impl.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/impl.asm\n[CMD]: ld -o impl src/tests/impl.o\n",
+  "stderr": ""
+}

--- a/src/tests/impl.try_run
+++ b/src/tests/impl.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "Private Field\n12345\n",
+  "stderr": ""
+}

--- a/src/tests/struct.hay
+++ b/src/tests/struct.hay
@@ -1,6 +1,7 @@
 include "std.hay"
 struct pair {
-    u64: first u64: second
+    pub u64: first 
+    pub u64: second
 }
 
 fn main() {

--- a/src/tests/struct_accessors.hay
+++ b/src/tests/struct_accessors.hay
@@ -2,8 +2,8 @@
 include "std.hay"
 
 struct Words {
-    Str: hello
-    Str: world
+    pub Str: hello
+    pub Str: world
 }
 
 fn main() {


### PR DESCRIPTION
Struct members are now private by default, and thus cannot be accessed with `::`. For example:
```
struct Foo {
    u64: bar
}
fn main() {
    10 cast(Foo) as [foo]
    foo::bar // this doesn't compile because bar is private
}
```

Struct members can be marked public like so:
```
struct Foo {
    pub u64: bar
}
```

You can create functions that can access private members if they are defined inside the struct definition like so:
```
struct Foo {
    u64: bar

impl:
    fn get_bar(Foo: foo) -> [u64] { foo::bar }
}
```

Overall, this makes it easier for users to ensure that their types and functions aren't misused along with the removal of the `split` keyword.

Closes #48
