### PR TITLE
AddressOf Operation

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -211,7 +211,7 @@ impl Expr {
             } => {
                 let (_, mut sig) = global_env
                     .get(&base.lexeme)
-                    .expect(format!("Should have found function: {base}").as_str())
+                    .unwrap_or_else(|| panic!("Should have found function: {base}"))
                     .clone();
 
                 let (annotations, tid) = if annotations

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -933,13 +933,10 @@ impl Expr {
                                         idx,
                                     })
                                 }
-                                None => todo!("Error out "),
-                                // stack.push(tid.clone());
-                                // return Ok(TypedExpr::Framed {
-                                //     frame: frame.clone(),
-                                //     idx: i,
-                                //     inner: None,
-                                // });
+                                None => Err(HayError::new_type_err(
+                                    format!("Can't take address of unknown identifier: `{ident}`"),
+                                    op_tok.loc,
+                                )),
                             }
                         }
                     }
@@ -1305,5 +1302,10 @@ mod tests {
     #[test]
     fn var_unknown_type() -> Result<(), std::io::Error> {
         crate::compiler::test_tools::run_test("type_check", "var_unknown_type")
+    }
+
+    #[test]
+    fn address_of_unknown_ident() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test("type_check", "address_of_unknown_ident")
     }
 }

--- a/src/backend/instruction.rs
+++ b/src/backend/instruction.rs
@@ -33,7 +33,6 @@ pub enum Instruction {
     },
     PushPtrToFrame {
         offset_from_end: usize,
-        bytes: usize,
     },
     FramePtrToFrameReserve {
         offset: usize,
@@ -167,8 +166,9 @@ impl Instruction {
                 for (_, tid) in &frame[idx + 1..] {
                     offset += tid.size(types).unwrap();
                 }
-
-                todo!()
+                ops.push(Instruction::PushPtrToFrame {
+                    offset_from_end: offset,
+                })
             }
             TypedExpr::Operator { op, typ: Some(typ) } => ops.push(Instruction::Operator {
                 op,

--- a/src/backend/instruction.rs
+++ b/src/backend/instruction.rs
@@ -31,6 +31,10 @@ pub enum Instruction {
         offset_from_end: usize,
         bytes: usize,
     },
+    PushPtrToFrame {
+        offset_from_end: usize,
+        bytes: usize,
+    },
     FramePtrToFrameReserve {
         offset: usize,
         size: usize,
@@ -156,6 +160,15 @@ impl Instruction {
                 };
 
                 ops.push(i);
+            }
+            TypedExpr::AddrFramed { frame, idx } => {
+                assert!(idx < frame.len());
+                let mut offset = 0;
+                for (_, tid) in &frame[idx + 1..] {
+                    offset += tid.size(types).unwrap();
+                }
+
+                todo!()
             }
             TypedExpr::Operator { op, typ: Some(typ) } => ops.push(Instruction::Operator {
                 op,

--- a/src/backend/x86_64_nasm.rs
+++ b/src/backend/x86_64_nasm.rs
@@ -43,9 +43,12 @@ impl super::CodeGen for X86_64 {
                 }
             }
             Instruction::PushPtrToFrame {
-                offset_from_end,
-                bytes,
-            } => todo!(),
+                offset_from_end, ..
+            } => {
+                writeln!(file, "  mov rax, [frame_end_ptr]")?;
+                writeln!(file, "  add rax, {}", offset_from_end * 8)?;
+                writeln!(file, "  push rax")?;
+            }
             Instruction::PushToFrame { quad_words } => {
                 for _ in 0..*quad_words {
                     writeln!(file, "  pop  rax")?;

--- a/src/backend/x86_64_nasm.rs
+++ b/src/backend/x86_64_nasm.rs
@@ -42,6 +42,10 @@ impl super::CodeGen for X86_64 {
                     writeln!(file, "  add rax, 8")?;
                 }
             }
+            Instruction::PushPtrToFrame {
+                offset_from_end,
+                bytes,
+            } => todo!(),
             Instruction::PushToFrame { quad_words } => {
                 for _ in 0..*quad_words {
                     writeln!(file, "  pop  rax")?;
@@ -152,7 +156,7 @@ impl super::CodeGen for X86_64 {
                     writeln!(file, "  cmovne rcx, rdx")?;
                     writeln!(file, "  push rcx")?;
                 }
-                Operator::Read | Operator::Write => unreachable!(),
+                Operator::Read | Operator::Write | Operator::Address(_) => unreachable!(),
             },
             Instruction::Operator {
                 op,

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -109,7 +109,7 @@ mod tests {
     }
 
     #[test]
-    fn r#enum() -> Result<(), std::io::Error> {
+    fn hay_enum() -> Result<(), std::io::Error> {
         super::test_tools::run_test("functional", "enum")
     }
 
@@ -129,7 +129,7 @@ mod tests {
     }
 
     #[test]
-    fn r#impl() -> Result<(), std::io::Error> {
+    fn hay_impl() -> Result<(), std::io::Error> {
         super::test_tools::run_test("functional", "impl")
     }
 
@@ -179,13 +179,18 @@ mod tests {
     }
 
     #[test]
-    fn r#struct() -> Result<(), std::io::Error> {
+    fn hay_struct() -> Result<(), std::io::Error> {
         super::test_tools::run_test("functional", "struct")
     }
 
     #[test]
-    fn r#union() -> Result<(), std::io::Error> {
+    fn hay_union() -> Result<(), std::io::Error> {
         super::test_tools::run_test("functional", "union")
+    }
+
+    #[test]
+    fn address_of_framed() -> Result<(), std::io::Error> {
+        super::test_tools::run_test("functional", "address_of_framed")
     }
 
     #[test]

--- a/src/lex/scanner.rs
+++ b/src/lex/scanner.rs
@@ -174,6 +174,30 @@ impl Scanner {
                 }
             }
             '@' => self.add_token(TokenKind::Operator(Operator::Read)),
+            '&' => {
+                if self.peek(0).is_alphabetic() {
+                    // Pushes either Keyword, Syscall, or Ident
+                    self.identifier()?;
+                    let ident = match self.tokens.pop().unwrap() {
+                        Token {
+                            kind: TokenKind::Ident(ident),
+                            ..
+                        } => ident,
+                        Token { kind, loc, .. } => {
+                            return Err(HayError::new(
+                                format!("Expected an identifier, but found {}", kind),
+                                loc,
+                            ))
+                        }
+                    };
+
+                    self.add_token(TokenKind::Operator(Operator::Address(String::from(
+                        &ident[1..],
+                    ))))
+                } else {
+                    unimplemented!("Binary and operator isn't implemented yet")
+                }
+            }
             ' ' | '\t' | '\r' => (),
             '\n' => self.newline(),
             '"' => self.string()?,

--- a/src/lex/scanner.rs
+++ b/src/lex/scanner.rs
@@ -183,12 +183,7 @@ impl Scanner {
                             kind: TokenKind::Ident(ident),
                             ..
                         } => ident,
-                        Token { kind, loc, .. } => {
-                            return Err(HayError::new(
-                                format!("Expected an identifier, but found {}", kind),
-                                loc,
-                            ))
-                        }
+                        _ => unreachable!(),
                     };
 
                     self.add_token(TokenKind::Operator(Operator::Address(String::from(

--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -60,7 +60,7 @@ impl std::fmt::Display for Marker {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Operator {
     Plus,
     Minus,
@@ -75,6 +75,7 @@ pub enum Operator {
     Modulo,
     Read,
     Write,
+    Address(String),
 }
 
 impl std::fmt::Display for Operator {
@@ -94,6 +95,7 @@ impl std::fmt::Display for Operator {
             Operator::Modulo => write!(f, "%")?,
             Operator::Read => write!(f, "@")?,
             Operator::Write => write!(f, "!")?,
+            Operator::Address(ident) => write!(f, "&{ident}")?,
         }
         write!(f, "`")
     }

--- a/src/tests/functional/address_of_framed.hay
+++ b/src/tests/functional/address_of_framed.hay
@@ -1,0 +1,47 @@
+include "std.hay"
+include "alloc.hay"
+struct MyVec<T> {
+
+    Arr<T>: slice
+    u64:    len
+
+impl:
+    fn MyVec.new<T>() -> [MyVec<T>] {
+
+        32 malloc::<T>
+        0
+        cast(MyVec)
+    }
+
+    fn MyVec.push<T>(T: item *MyVec<T>: ptr) {
+        ptr @ as [self]
+        item self::len self::slice Arr.set
+        self::slice self::len 1 + cast(MyVec) ptr !
+    }
+
+    fn MyVec.get<T>(u64: idx *MyVec<T>: ptr) -> [T] {
+
+        ptr @ as [self]
+        idx self::slice Arr.get
+
+    }
+}
+
+fn main() {
+
+    12345 MyVec.new::<u64> "Hello World" as [n list str]
+    0 while dup 10 < {
+        dup &list MyVec.push
+        1 +
+    }
+
+    0 while dup 10 < {
+        dup &list MyVec.get putlnu
+        1 +
+    }
+
+    &str @ putlns
+    &n @ putlnu
+
+
+}

--- a/src/tests/functional/address_of_framed.try_com
+++ b/src/tests/functional/address_of_framed.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/functional/address_of_framed.asm\n[CMD]: ld -o address_of_framed src/tests/functional/address_of_framed.o\n",
+  "stderr": ""
+}

--- a/src/tests/functional/address_of_framed.try_run
+++ b/src/tests/functional/address_of_framed.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "0\n1\n2\n3\n4\n5\n6\n7\n8\n9\nHello World\n12345\n",
+  "stderr": ""
+}

--- a/src/tests/type_check/address_of_unknown_ident.hay
+++ b/src/tests/type_check/address_of_unknown_ident.hay
@@ -1,0 +1,1 @@
+fn main() { &foo }

--- a/src/tests/type_check/address_of_unknown_ident.try_com
+++ b/src/tests/type_check/address_of_unknown_ident.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 1,
+  "stdout": "",
+  "stderr": "[src/tests/type_check/address_of_unknown_ident.hay:1:13] Error: Type Error: Can't take address of unknown identifier: `foo`\n"
+}


### PR DESCRIPTION
Adds support for `&ident` syntax to push a pointer to `ident`.
```
include "std.hay"
fn main() {
    12345 as [n]
    &n putlnu // prints `12345`
}
```

This will make it significantly easier to have data structures that can be mutated in place.
