### PR TITLE
Add suppport for pointer offsets to framed pointers

### DIFF
--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -1518,4 +1518,9 @@ mod tests {
     fn inner_address_of_private_member() -> Result<(), std::io::Error> {
         crate::compiler::test_tools::run_test("type_check", "inner_address_of_private_member")
     }
+
+    #[test]
+    fn multiple_pointer_offsets() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test("type_check", "multiple_pointer_offsets")
+    }
 }

--- a/src/ast/expr.rs
+++ b/src/ast/expr.rs
@@ -126,7 +126,7 @@ impl Expr {
                             let final_tid =
                                 tid.type_check_inner_accessors(token, &inner, func, types)?;
 
-                            stack.push(final_tid.clone());
+                            stack.push(final_tid);
                             Ok(TypedExpr::Framed {
                                 frame: frame.clone(),
                                 idx: i,

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -228,4 +228,9 @@ mod tests {
         );
         Ok(())
     }
+
+    #[test]
+    fn pointer_offsets() -> Result<(), std::io::Error> {
+        super::test_tools::run_test("functional", "pointer_offsets")
+    }
 }

--- a/src/libs/str.hay
+++ b/src/libs/str.hay
@@ -79,6 +79,18 @@ fn putlnb(bool) {
     putb "\n" puts
 }
 
+fn fputc(char: c u64: fd) {
+    1 &c cast(Str) fd fputs
+}
+
+fn putc(char) {
+    1 fputc
+}
+
+fn putlnc(char) {
+    putc "\n" puts
+}
+
 fn Str.drop_left(Str: s) -> [Str] {
     s::size 0 == if {
         s

--- a/src/tests/functional/pointer_offsets.hay
+++ b/src/tests/functional/pointer_offsets.hay
@@ -1,0 +1,43 @@
+include "std.hay"
+
+fn assert(bool) {
+    lnot if {
+        "Assertion failed!" putlns
+        1 exit
+    }
+}
+
+struct Foo {
+    pub u8: u8
+    pub char: char
+    pub bool: bool
+    pub Str: string
+}
+
+struct Bar {
+    pub bool: bool
+    pub Foo: foo
+    pub u64: number
+}
+
+fn test_ptr_offset(*Bar: bar) {
+    bar::foo::string @ putlns
+    "bar::bool:      " puts bar::bool @ putlnb 
+    "bar::foo::u8:   " puts bar::foo::u8 @ putlnu8
+    "bar::foo::char: " puts bar::foo::char @ putlnc
+    "bar::foo::bool: " puts bar::foo::bool @ putlnb 
+    "bar::number:    " puts bar::number    @ putlnu
+
+    bar::bool      @ false == assert
+    bar::foo::u8   @ 123u8 == assert 
+    bar::foo::char @ 'q'   == assert 
+    bar::foo::bool @ true  == assert 
+    bar::number    @ 54321 == assert 
+}
+fn main() {
+
+    123u8 'q' true "Hello World!" cast(Foo) as [f]
+    false f 54321 cast(Bar) as [bar]
+    &bar test_ptr_offset
+
+}

--- a/src/tests/functional/pointer_offsets.try_com
+++ b/src/tests/functional/pointer_offsets.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/functional/pointer_offsets.asm\n[CMD]: ld -o pointer_offsets src/tests/functional/pointer_offsets.o\n",
+  "stderr": ""
+}

--- a/src/tests/functional/pointer_offsets.try_run
+++ b/src/tests/functional/pointer_offsets.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "Hello World!\nbar::bool:      false\nbar::foo::u8:   123\nbar::foo::char: q\nbar::foo::bool: true\nbar::number:    54321\n",
+  "stderr": ""
+}

--- a/src/tests/type_check/multiple_pointer_offsets.hay
+++ b/src/tests/type_check/multiple_pointer_offsets.hay
@@ -1,0 +1,23 @@
+include "std.hay"
+
+struct Foo {
+    pub u64: bar
+    pub bool: baz
+}
+
+struct Bar {
+    pub *Foo: foo_p
+}
+
+fn work(*Bar: bar) {
+    bar::foo_p::bar @ putlnu
+    bar::foo_p::baz @ putlnb 
+}
+
+fn main() {
+
+    12345 true cast(Foo) as [foo]
+    &foo cast(Bar) as [bar]
+    &bar work
+
+}

--- a/src/tests/type_check/multiple_pointer_offsets.try_com
+++ b/src/tests/type_check/multiple_pointer_offsets.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 1,
+  "stdout": "",
+  "stderr": "[src/tests/type_check/multiple_pointer_offsets.hay:13:5] Error: Cannot access into non-record type `*Foo`\n"
+}

--- a/src/tests/type_check/non_record_accessor.try_com
+++ b/src/tests/type_check/non_record_accessor.try_com
@@ -1,5 +1,5 @@
 {
   "exit_code": 1,
   "stdout": "",
-  "stderr": "[src/tests/type_check/non_record_accessor.hay:4:5] Error: Cannot access into non-record type `u64`\n"
+  "stderr": "[src/tests/type_check/non_record_accessor.hay:4:5] Error: Type Error: Cannot access into non-record type `u64`\n"
 }


### PR DESCRIPTION
closes #73 

Adds support for the following syntax:
```
include "std.hay"
struct Foo {
    pub u64: bar
}

fn Foo.print_bar(*Foo: foo) {
    foo::bar @ putlnu
}

fn main() {
    12345 cast(Foo) as [f]
    &f Foo.print_bar
}
```