### PR TITLE
Add new types to stdlib

### DIFF
--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -295,4 +295,9 @@ mod tests {
     fn result() -> Result<(), std::io::Error> {
         super::test_tools::run_test("functional", "result")
     }
+
+    #[test]
+    fn hstring() -> Result<(), std::io::Error> {
+        super::test_tools::run_test("functional", "hstring")
+    }
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -290,4 +290,9 @@ mod tests {
     fn vec() -> Result<(), std::io::Error> {
         super::test_tools::run_test("functional", "vec")
     }
+
+    #[test]
+    fn result() -> Result<(), std::io::Error> {
+        super::test_tools::run_test("functional", "result")
+    }
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -285,4 +285,9 @@ mod tests {
     fn empty_string() -> Result<(), std::io::Error> {
         super::test_tools::run_test("functional", "empty_string")
     }
+
+    #[test]
+    fn vec() -> Result<(), std::io::Error> {
+        super::test_tools::run_test("functional", "vec")
+    }
 }

--- a/src/libs/assert.hay
+++ b/src/libs/assert.hay
@@ -1,0 +1,7 @@
+include "std.hay"
+fn assert(bool) {
+    lnot if {
+        "Assertion failed" putlns
+        1 exit 
+    }
+}

--- a/src/libs/hstring.hay
+++ b/src/libs/hstring.hay
@@ -1,0 +1,35 @@
+include "vec.hay"
+struct HString {
+    Vec<char>: chars
+
+impl:
+    fn HString.new(Str: s) -> [HString] {
+        Vec.new::<char> as [mut chars]
+        s::size 0 > if {
+            0 while dup s::size < {
+                as [i]
+                s::data i ptr+ @ *chars Vec.push
+                i 1 +
+            } drop
+        } else {
+            "Heap-allocated zero sized strings aren't supported" putlns
+            1 exit 
+        }
+        chars cast(HString)
+    }
+
+    fn HString.delete(&HString: self) {
+        self::chars Vec.delete
+    }
+
+    fn HString.size(&HString: self) -> [u64] {
+        self::chars Vec.len
+    }
+
+    fn HString.as_str(&HString: self) -> [Str] {
+        self HString.size
+        0 self::chars Vec.get Opt.unwrap
+        cast(Str)
+    }
+}
+

--- a/src/libs/result.hay
+++ b/src/libs/result.hay
@@ -1,0 +1,55 @@
+
+enum ResultTag {
+    Ok
+    Err
+}
+
+union ResultKind<T E> {
+    T: ok
+    E: err
+}
+
+struct Result<T E> {
+    ResultKind<T E>: kind
+    ResultTag: tag
+    
+impl:
+
+    fn Result.Ok<T E>(T) -> [Result<T E>] {
+        cast(ResultKind<T E>)
+        ResultTag::Ok
+        cast(Result<T E>)
+    }
+
+    fn Result.Err<T E>(E) -> [Result<T E>] {
+        cast(ResultKind<T E>)
+        ResultTag::Err
+        cast(Result<T E>)
+    }
+
+    fn Result.is_ok<T E>(Result<T E>: self) -> [bool] {
+        self::tag ResultTag::Ok ==
+    }
+
+    fn Result.is_err<T E>(Result<T E>: self) -> [bool] {
+        self::tag ResultTag::Err ==
+    }
+
+    fn Result.unwrap<T E>(Result<T E>: self) -> [T] {
+
+        self Result.is_err if {
+            "Tried to `unwrap` an Error result" putlns
+            1 exit
+        }
+        self::kind::ok
+    }
+
+    fn Result.unwrap_err<T E>(Result<T E>: self) -> [E] {
+
+        self Result.is_ok if {
+            "Tried to `unwrap_err` on an Ok result" putlns
+            1 exit
+        }
+        self::kind::err
+    }
+}

--- a/src/libs/vec.hay
+++ b/src/libs/vec.hay
@@ -1,0 +1,63 @@
+include "alloc.hay"
+include "assert.hay"
+struct Vec<T> {
+    Arr<T>: slice
+    u64: len
+impl:
+    fn Vec.new<T>() -> [Vec<T>] {
+        8 malloc::<T> 0 cast(Vec) 
+    }
+
+    fn Vec.delete<T>(&Vec<T>: self) {
+        self::slice @ free
+    }
+
+    fn Vec.push<T>(T: value *Vec<T>: self) {
+        self::len @ self::slice::size @ == if {
+            self::slice::size @ 2 * self::slice @ realloc self::slice !
+        }
+        value self::len @ self::slice @ Arr.set
+        self::len @ 1 + self::len !
+    }
+
+    fn Vec.pop<T>(*Vec<T>: self) -> [Opt<T>] {
+        self::len @ 0 == if {
+            Opt.None::<T>
+        } else {
+            self::len @ 1 - self::len !
+            self::len @ self::slice @ Arr.get Opt.Some
+        }
+    }
+
+    fn Vec.get<T>(u64: idx &Vec<T>: self) -> [Opt<&T>] {
+        idx self::len @ >= if {
+            Opt.None::<&T>
+        } else {
+            idx self::slice @ Arr.get_ref Opt.Some
+        }
+    }
+
+    fn Vec.get_mut<T>(u64: idx *Vec<T>: self) -> [Opt<*T>] {
+        idx self::len @ >= if {
+            Opt.None::<*T>
+        } else {
+            idx self::slice @ Arr.get_ref_mut Opt.Some
+        }
+    }
+
+    fn Vec.at<T>(u64: idx &Vec<T>: self) -> [Opt<T>] {
+        idx self::len @ >= if {
+            Opt.None::<T>
+        } else {
+            idx self::slice @ Arr.get Opt.Some
+        }
+    }
+
+    fn Vec.capacity<T>(&Vec<T>: self) -> [u64] {
+        self::slice::size @
+    }
+
+    fn Vec.len<T>(&Vec<T>: self) -> [u64] {
+        self::len @
+    }
+}

--- a/src/tests/functional/hstring.hay
+++ b/src/tests/functional/hstring.hay
@@ -1,0 +1,16 @@
+include "hstring.hay"
+
+fn main() {
+
+    "Hello World" as [s] 
+    s HString.new as [hs]
+    Heap.debug_summary
+
+    s::size          putlnu
+    &hs HString.size putlnu
+    s                  putlns
+    &hs HString.as_str putlns
+    &hs HString.delete
+    Heap.debug_summary
+
+}

--- a/src/tests/functional/hstring.try_com
+++ b/src/tests/functional/hstring.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/functional/hstring.asm\n[CMD]: ld -o hstring src/tests/functional/hstring.o\n",
+  "stderr": ""
+}

--- a/src/tests/functional/hstring.try_run
+++ b/src/tests/functional/hstring.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "Heap:\n  * [ | 8 false |  | 16 true |  | 4000 false | ] 4096\n11\n11\nHello World\nHello World\nHeap:\n  * [ | 4072 false | ] 4096\n",
+  "stderr": ""
+}

--- a/src/tests/functional/result.hay
+++ b/src/tests/functional/result.hay
@@ -1,0 +1,15 @@
+include "result.hay"
+include "assert.hay"
+fn main() {
+
+    12345 Result.Ok::<u64 Str> as [r] {
+        r Result.is_ok assert 
+        r Result.unwrap putlnu
+    } 
+
+    "Error Result!" Result.Err::<u64 Str> as [r] {
+        r Result.is_err assert 
+        r Result.unwrap_err putlns
+    }
+
+}

--- a/src/tests/functional/result.try_com
+++ b/src/tests/functional/result.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/functional/result.asm\n[CMD]: ld -o result src/tests/functional/result.o\n",
+  "stderr": ""
+}

--- a/src/tests/functional/result.try_run
+++ b/src/tests/functional/result.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "12345\nError Result!\n",
+  "stderr": ""
+}

--- a/src/tests/functional/vec.hay
+++ b/src/tests/functional/vec.hay
@@ -1,0 +1,33 @@
+include "vec.hay"
+fn main() {
+
+    Vec.new::<u64> as [mut vec]
+    "Initial capacity: " puts &vec Vec.capacity putlnu
+    
+    0 while dup 4069 < {
+        as [i]
+        i *vec Vec.push
+        i 1 +
+    } drop
+    "Heap after pushing: " putlns
+    Heap.debug_summary
+
+    "Element 1234: " puts 1234 &vec Vec.get     Opt.unwrap @ putlnu
+    "Element 2345: " puts 2345 *vec Vec.get_mut Opt.unwrap @ putlnu
+    "Element 4068: " puts 4068 &vec Vec.at      Opt.unwrap   putlnu
+
+    4069 &vec Vec.get     Opt.is_none assert
+    4069 *vec Vec.get_mut Opt.is_none assert
+    4069 &vec Vec.at      Opt.is_none assert
+
+    0 while *vec Vec.pop Opt.is_some {
+        1 + 
+    }
+
+    "Popped: " puts putu " elements" putlns
+
+    &vec Vec.delete
+    "Heap after freeing: " putlns
+    Heap.debug_summary
+
+}

--- a/src/tests/functional/vec.try_com
+++ b/src/tests/functional/vec.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/functional/vec.asm\n[CMD]: ld -o vec src/tests/functional/vec.o\n",
+  "stderr": ""
+}

--- a/src/tests/functional/vec.try_run
+++ b/src/tests/functional/vec.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "Initial capacity: 8\nHeap after pushing: \nHeap:\n  * [ | 4072 false | ] 4096\n  * [ | 4072 false | ] 4096\n  * [ | 8168 false | ] 8192\n  * [ | 12264 false | ] 12288\n  * [ | 20456 false | ] 20480\n  * [ | 32768 true |  | 4048 false | ] 36864\nElement 1234: 1234\nElement 2345: 2345\nElement 4068: 4068\nPopped: 4069 elements\nHeap after freeing: \nHeap:\n  * [ | 4072 false | ] 4096\n  * [ | 4072 false | ] 4096\n  * [ | 8168 false | ] 8192\n  * [ | 12264 false | ] 12288\n  * [ | 20456 false | ] 20480\n  * [ | 36840 false | ] 36864\n",
+  "stderr": ""
+}


### PR DESCRIPTION
Adds a `vec`, `result`, and heap based string (`HString`) to `src/libs`
closes #101

These types use many of the new features created within the last month.