### PR TITLE
Generic Blanket Interface Implementations

### DIFF
--- a/src/ast/expr/as.rs
+++ b/src/ast/expr/as.rs
@@ -25,7 +25,7 @@ impl ExprAs {
         stack: &mut Stack,
         frame: &mut Frame,
         func: &UncheckedFunction,
-        global_env: &HashMap<String, (StmtKind, Signature)>,
+        global_env: &mut HashMap<String, (StmtKind, Signature)>,
         types: &mut TypeMap,
         generic_map: &Option<HashMap<TypeId, TypeId>>,
     ) -> Result<TypedExpr, HayError> {

--- a/src/ast/expr/expr_typ.rs
+++ b/src/ast/expr/expr_typ.rs
@@ -80,7 +80,7 @@ impl Expr {
         stack: &mut Stack,
         frame: &mut Frame,
         func: &UncheckedFunction,
-        global_env: &HashMap<String, (StmtKind, Signature)>,
+        global_env: &mut HashMap<String, (StmtKind, Signature)>,
         types: &mut TypeMap,
         generic_map: &Option<HashMap<TypeId, TypeId>>,
     ) -> Result<TypedExpr, HayError> {

--- a/src/ast/expr/ident.rs
+++ b/src/ast/expr/ident.rs
@@ -20,7 +20,7 @@ impl ExprIdent {
         stack: &mut Stack,
         frame: &Frame,
         types: &mut TypeMap,
-        global_env: &HashMap<String, (StmtKind, Signature)>,
+        global_env: &mut HashMap<String, (StmtKind, Signature)>,
     ) -> Result<TypedExpr, HayError> {
         match global_env.get(&self.ident.lexeme) {
             Some((StmtKind::Function, sig)) => {

--- a/src/ast/expr/if.rs
+++ b/src/ast/expr/if.rs
@@ -28,7 +28,7 @@ impl ExprIf {
         stack: &mut Stack,
         frame: &mut Frame,
         func: &UncheckedFunction,
-        global_env: &HashMap<String, (StmtKind, Signature)>,
+        global_env: &mut HashMap<String, (StmtKind, Signature)>,
         types: &mut TypeMap,
         generic_map: &Option<HashMap<TypeId, TypeId>>,
     ) -> Result<TypedExpr, HayError> {
@@ -142,7 +142,7 @@ impl ExprElseIf {
         frame: &mut Frame,
         types: &mut TypeMap,
         func: &UncheckedFunction,
-        global_env: &HashMap<String, (StmtKind, Signature)>,
+        global_env: &mut HashMap<String, (StmtKind, Signature)>,
         generic_map: &Option<HashMap<TypeId, TypeId>>,
     ) -> Result<(TypedExpr, Stack), HayError> {
         let mut typed_condition = vec![];

--- a/src/ast/expr/while.rs
+++ b/src/ast/expr/while.rs
@@ -25,7 +25,7 @@ impl ExprWhile {
         stack: &mut Stack,
         frame: &mut Frame,
         func: &UncheckedFunction,
-        global_env: &HashMap<String, (StmtKind, Signature)>,
+        global_env: &mut HashMap<String, (StmtKind, Signature)>,
         types: &mut TypeMap,
         generic_map: &Option<HashMap<TypeId, TypeId>>,
     ) -> Result<TypedExpr, HayError> {

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -161,4 +161,9 @@ mod tests {
     fn non_generic_record_requirements() -> Result<(), std::io::Error> {
         crate::compiler::test_tools::run_test("stmt", "non_generic_record_requirements")
     }
+
+    #[test]
+    fn blanket_impl_requirement_breach() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test("stmt", "blanket_impl_requirement_breach")
+    }
 }

--- a/src/ast/parser.rs
+++ b/src/ast/parser.rs
@@ -213,6 +213,13 @@ impl<'a> Parser<'a> {
             Err(_) => None,
         };
 
+        if requires.is_some() && generics.is_none(){
+            return Err(HayError::new(
+                "Cannot have a requires block on a non-generic interface implementation.", 
+                requires.as_ref().unwrap().first().unwrap().loc.clone()
+            ));
+        }
+
         if let Err(t) = self.matches(TokenKind::Marker(Marker::LeftBrace)) {
             return Err(HayError::new(
                 format!(
@@ -1946,6 +1953,16 @@ mod tests {
     #[test]
     fn parse_bad_requirement_start() -> Result<(), std::io::Error> {
         crate::compiler::test_tools::run_test("parser", "parse_bad_requirement_start")
+    }
+
+    #[test]
+    fn parse_bad_generic_impl_close() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test("parser", "parse_bad_generic_impl_close")
+    }
+
+    #[test]
+    fn parse_bad_generic_impl_requires() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test("parser", "parse_bad_generic_impl_requires")
     }
 
 }

--- a/src/ast/stmt/impl.rs
+++ b/src/ast/stmt/impl.rs
@@ -254,6 +254,14 @@ impl InterfaceImplStmt {
                     func.name.lexeme = new_fn_name.clone();
                     let (_, mut interface_sig) = global_env.get(f).unwrap().clone();
                     interface_sig.assign(&interface.token, &mapped, types)?;
+                    if let Some(generics) = &self.generics {
+                        interface_sig.generics = Some(
+                            generics
+                                .iter()
+                                .map(|arg| TypeId::new(&arg.token.lexeme))
+                                .collect(),
+                        );
+                    }
 
                     func.inputs = interface_sig
                         .inputs

--- a/src/ast/stmt/impl.rs
+++ b/src/ast/stmt/impl.rs
@@ -14,7 +14,7 @@ use crate::{
     },
 };
 
-use super::{FunctionStmt, GlobalEnv};
+use super::{FunctionStmt, GlobalEnv, Stmt};
 
 #[derive(Clone)]
 pub struct InterfaceImplStmt {
@@ -102,9 +102,11 @@ impl InterfaceImplStmt {
             to_define.insert(key);
         }
 
+        let local_generics = Stmt::bulid_local_generics(self.generics.clone(), types, None)?;
+
         for t in self.types {
             let tid = TypeId::new(t.ident.lexeme);
-            let typ = TypeId::from_token(&t.token, types, &vec![])?;
+            let typ = TypeId::from_token(&t.token, types, &local_generics)?;
             if to_define.remove(&tid) {
                 map.insert(tid, typ);
             } else if map.contains_key(&tid) {

--- a/src/ast/stmt/impl.rs
+++ b/src/ast/stmt/impl.rs
@@ -1,10 +1,17 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::{
-    ast::{arg::TypedArg, member::UntypedMember, stmt::StmtKind},
+    ast::{
+        arg::{TypedArg, UntypedArg},
+        member::UntypedMember,
+        stmt::StmtKind,
+    },
     error::HayError,
     lex::token::{Token, TokenKind, TypeToken},
-    types::{check_requirements, InterfaceInstanceType, Type, TypeId, TypeMap, UncheckedFunction},
+    types::{
+        check_requirements, GenericFunction, InterfaceInstanceType, Type, TypeId, TypeMap,
+        UncheckedFunction,
+    },
 };
 
 use super::{FunctionStmt, GlobalEnv};
@@ -15,19 +22,38 @@ pub struct InterfaceImplStmt {
     pub interface: Token,
     pub types: Vec<UntypedMember>,
     pub fns: Vec<FunctionStmt>,
+    pub generics: Option<Vec<UntypedArg>>,
+    pub requires: Option<Vec<Token>>,
 }
 
 impl InterfaceImplStmt {
+    fn is_generic(&self) -> bool {
+        self.generics.is_some()
+    }
+
     pub fn add_to_global_scope(
         self,
         types: &mut TypeMap,
         global_env: &mut GlobalEnv,
     ) -> Result<(), HayError> {
+        let is_generic = self.is_generic();
         let (base, inner) = match &self.interface.kind {
             TokenKind::Type(TypeToken::Parameterized { base, inner }) => {
                 let mut inner_tids = vec![];
                 for t in inner {
-                    inner_tids.push(TypeId::from_type_token(&self.interface, t, types, &vec![])?);
+                    inner_tids.push(TypeId::from_type_token(
+                        &self.interface,
+                        t,
+                        types,
+                        &if let Some(generics) = &self.generics {
+                            generics
+                                .iter()
+                                .map(|arg| TypeId::new(&arg.token.lexeme))
+                                .collect()
+                        } else {
+                            vec![]
+                        },
+                    )?);
                 }
                 (base, inner_tids)
             }
@@ -157,8 +183,10 @@ impl InterfaceImplStmt {
                     new_fn_name = format!("{new_fn_name}{}>", mapped.last().unwrap());
 
                     f.name.lexeme = new_fn_name.clone();
+                    f.annotations = self.generics.clone();
 
                     let tok = f.name.clone();
+
                     // Insert the concrete functions renamed
                     f.add_to_global_scope(types, global_env, None, StmtKind::Function)?;
 
@@ -250,19 +278,45 @@ impl InterfaceImplStmt {
                         })
                         .collect();
 
-                    let func = UncheckedFunction {
-                        token: func.token,
-                        name: func.name,
-                        inputs: func.inputs,
-                        outputs: func.outputs,
-                        body: func.body,
-                        generic_map: Some(map.clone()),
-                        tags: func.tags,
-                        impl_on: func.impl_on,
+                    let new_tid = if !is_generic {
+                        let func = UncheckedFunction {
+                            token: func.token,
+                            name: func.name,
+                            inputs: func.inputs,
+                            outputs: func.outputs,
+                            body: func.body,
+                            generic_map: Some(map.clone()),
+                            tags: func.tags,
+                            impl_on: func.impl_on,
+                        };
+
+                        let new_tid = TypeId::new(&new_fn_name);
+                        types.insert(new_tid.clone(), Type::UncheckedFunction { func });
+                        new_tid
+                    } else {
+                        let func = GenericFunction {
+                            token: func.token,
+                            name: func.name,
+                            inputs: func.inputs,
+                            outputs: func.outputs,
+                            body: func.body,
+                            tags: func.tags,
+                            impl_on: func.impl_on,
+                            generics: self
+                                .generics
+                                .as_ref()
+                                .unwrap()
+                                .iter()
+                                .map(|arg| TypeId::new(&arg.token.lexeme))
+                                .collect(),
+                            requires: self.requires.clone(),
+                        };
+
+                        let new_tid = TypeId::new(&new_fn_name);
+                        types.insert(new_tid.clone(), Type::GenericFunction { func });
+                        new_tid
                     };
 
-                    let new_tid = TypeId::new(&new_fn_name);
-                    types.insert(new_tid.clone(), Type::UncheckedFunction { func });
                     fns_map.insert(tid, new_tid);
                     global_env.insert(new_fn_name, (StmtKind::Function, interface_sig));
                 }
@@ -294,8 +348,20 @@ impl InterfaceImplStmt {
                 lexeme: base.clone(),
                 loc: self.interface.loc,
             },
+            base: interface_tid.clone(),
             mapping: mapped,
             fns_map,
+            generics: if let Some(generics) = self.generics {
+                Some(
+                    generics
+                        .iter()
+                        .map(|arg| TypeId::new(&arg.token.lexeme))
+                        .collect(),
+                )
+            } else {
+                None
+            },
+            requires: self.requires,
         });
 
         let instance_tid = instance_typ.id();

--- a/src/ast/stmt/impl.rs
+++ b/src/ast/stmt/impl.rs
@@ -361,16 +361,12 @@ impl InterfaceImplStmt {
             base: interface_tid.clone(),
             mapping: mapped,
             fns_map,
-            generics: if let Some(generics) = self.generics {
-                Some(
-                    generics
-                        .iter()
-                        .map(|arg| TypeId::new(&arg.token.lexeme))
-                        .collect(),
-                )
-            } else {
-                None
-            },
+            generics: self.generics.map(|generics| {
+                generics
+                    .iter()
+                    .map(|arg| TypeId::new(&arg.token.lexeme))
+                    .collect()
+            }),
             requires: self.requires,
         });
 

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -97,7 +97,7 @@ fn check_for_entry_point(types: &TypeMap, input_path: &String) -> Result<(), Hay
     }
 }
 
-mod tests {
+mod functional {
     #[test]
     fn early_return_basic() -> Result<(), std::io::Error> {
         super::test_tools::run_test("functional", "early_return_basic")
@@ -305,5 +305,10 @@ mod tests {
     #[test]
     fn interface() -> Result<(), std::io::Error> {
         super::test_tools::run_test("functional", "interface")
+    }
+
+    #[test]
+    fn blanket_impl() -> Result<(), std::io::Error> {
+        super::test_tools::run_test("functional", "blanket_impl")
     }
 }

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -11,8 +11,9 @@ pub mod test_tools;
 
 pub fn compile_haystack(input_path: String, run: bool) -> Result<(), HayError> {
     let stmts = Stmt::from_file_with_prelude(&input_path)?;
-    let (mut types, global_env, mut init_data, uninit_data) = Stmt::build_types_and_data(stmts)?;
-    Type::type_check_functions(&mut types, &global_env)?;
+    let (mut types, mut global_env, mut init_data, uninit_data) =
+        Stmt::build_types_and_data(stmts)?;
+    Type::type_check_functions(&mut types, &mut global_env)?;
     let fn_instructions = Instruction::from_type_map(&types, &mut init_data);
     check_for_entry_point(&types, &input_path)?;
 

--- a/src/tests/functional/blanket_impl.hay
+++ b/src/tests/functional/blanket_impl.hay
@@ -1,0 +1,57 @@
+include "std.hay"
+include "opt.hay"
+include "vec.hay"
+
+interface MyPrint<T> {
+    fn my_print(T)
+    fn my_println(T) { my_print "\n" my_print}
+}
+
+impl MyPrint<Str> {
+    fn my_print(Str) { puts }
+}
+
+impl MyPrint<u64> {
+    fn my_print(u64) { putu }
+}
+
+impl<T> MyPrint<&T>
+requires: [MyPrint<T>] {
+    fn my_print(&T) { @ my_print }
+}
+
+interface MyIterator<T> {
+	_: Item
+	fn my_next(T) -> [Opt<Item> bool]
+}
+
+impl<T> MyIterator<*Vec<T>> {
+	T: Item
+	fn my_next(*Vec<T>: self) -> [Opt<T> bool]{
+		self Vec.pop as [t]
+		t &t Opt.is_some
+	}
+}
+
+fn main() {
+
+    "Hello world!" my_println
+    12345          my_println
+
+    54321 "Hello Print!" as [x y]
+    &x             my_println
+    &y             my_println
+
+    Vec.new::<u64> as [mut v]
+
+	0 while dup 10 < {
+		as [i] 
+		i *v Vec.push
+		i 1 +
+	} drop 
+
+	while *v my_next {
+		Opt.unwrap my_println
+	} drop
+
+}

--- a/src/tests/functional/blanket_impl.try_com
+++ b/src/tests/functional/blanket_impl.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/functional/blanket_impl.asm\n[CMD]: ld -o blanket_impl src/tests/functional/blanket_impl.o\n",
+  "stderr": ""
+}

--- a/src/tests/functional/blanket_impl.try_run
+++ b/src/tests/functional/blanket_impl.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "Hello world!\n12345\n54321\nHello Print!\n9\n8\n7\n6\n5\n4\n3\n2\n1\n0\n",
+  "stderr": ""
+}

--- a/src/tests/parser/parse_bad_generic_impl_close.hay
+++ b/src/tests/parser/parse_bad_generic_impl_close.hay
@@ -1,0 +1,1 @@
+impl<Foo

--- a/src/tests/parser/parse_bad_generic_impl_close.try_com
+++ b/src/tests/parser/parse_bad_generic_impl_close.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 1,
+  "stdout": "",
+  "stderr": "[src/tests/parser/parse_bad_generic_impl_close.hay:1:6] Error: Expected `>` after impl annotations, but found end of file instead.\n"
+}

--- a/src/tests/parser/parse_bad_generic_impl_requires.hay
+++ b/src/tests/parser/parse_bad_generic_impl_requires.hay
@@ -1,0 +1,5 @@
+impl Foo
+requires: [Bar<u64>]
+{
+    
+}

--- a/src/tests/parser/parse_bad_generic_impl_requires.try_com
+++ b/src/tests/parser/parse_bad_generic_impl_requires.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 1,
+  "stdout": "",
+  "stderr": "[src/tests/parser/parse_bad_generic_impl_requires.hay:2:12] Error: Cannot have a requires block on a non-generic interface implementation.\n"
+}

--- a/src/tests/stmt/blanket_impl_requirement_breach.hay
+++ b/src/tests/stmt/blanket_impl_requirement_breach.hay
@@ -1,0 +1,21 @@
+include "std.hay" 
+interface MyPrint<T> {
+    fn my_print(T)
+}
+
+impl MyPrint<u64> {
+    fn my_print(u64) { putlnu }
+}
+
+impl<T> MyPrint<&T>
+requires: [MyPrint<T>]
+{
+    fn my_print(&T) { @ print }
+}
+
+fn main() {
+
+    true as [b]
+    &b my_print
+
+}

--- a/src/tests/stmt/blanket_impl_requirement_breach.try_com
+++ b/src/tests/stmt/blanket_impl_requirement_breach.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 1,
+  "stdout": "",
+  "stderr": "[src/tests/stmt/blanket_impl_requirement_breach.hay:19:8] Error: Type Error: Failed to resolve interface function `my_print`\n    [Note]: Interface `MyPrint<T>` is implemented by:\n    [Note]:   MyPrint<u64>\n    [Note]:   MyPrint<&T> where MyPrint<T> is satisfied.\n    [Note]: Function `my_print` expected:\n    [Note]:   [T]\n    [Note]: Found:\n    [Note]:   [&bool]\n"
+}

--- a/src/types/function.rs
+++ b/src/types/function.rs
@@ -77,7 +77,7 @@ impl Function {
 impl UncheckedFunction {
     pub fn type_check(
         &self,
-        global_env: &GlobalEnv,
+        global_env: &mut GlobalEnv,
         types: &mut TypeMap,
     ) -> Result<Function, HayError> {
         let mut stack = vec![];

--- a/src/types/signature.rs
+++ b/src/types/signature.rs
@@ -386,11 +386,6 @@ impl<'pred> Signature<'pred> {
         annotations: &[TypeId],
         types: &mut TypeMap,
     ) -> Result<(), HayError> {
-        assert!(
-            annotations.iter().all(|t| !t.is_generic(types)),
-            "{token}: Signature::assign expects that all mapped values are concrete."
-        );
-
         // Check that the signature is generic. Doesn't make sense to assign
         // geneircs to a non-geneirc Signature.
         if self.generics.is_none() {

--- a/src/types/signature.rs
+++ b/src/types/signature.rs
@@ -386,6 +386,11 @@ impl<'pred> Signature<'pred> {
         annotations: &[TypeId],
         types: &mut TypeMap,
     ) -> Result<(), HayError> {
+        assert!(
+            annotations.iter().all(|t| !t.is_generic(types)),
+            "{token}: Signature::assign expects that all mapped values are concrete."
+        );
+
         // Check that the signature is generic. Doesn't make sense to assign
         // geneircs to a non-geneirc Signature.
         if self.generics.is_none() {

--- a/src/types/type.rs
+++ b/src/types/type.rs
@@ -190,7 +190,7 @@ impl Type {
 
     pub fn type_check_functions(
         types: &mut TypeMap,
-        global_env: &GlobalEnv,
+        global_env: &mut GlobalEnv,
     ) -> Result<(), HayError> {
         while types
             .iter()
@@ -216,7 +216,10 @@ impl Type {
         if let Type::Function { func } = self {
             func
         } else {
-            panic!("Tried to extract a function from a non-function type");
+            panic!(
+                "Tried to extract a function from a non-function type: {:?}",
+                self
+            );
         }
     }
 

--- a/src/types/type.rs
+++ b/src/types/type.rs
@@ -216,10 +216,7 @@ impl Type {
         if let Type::Function { func } = self {
             func
         } else {
-            panic!(
-                "Tried to extract a function from a non-function type: {:?}",
-                self
-            );
+            panic!("Tried to extract a function from a non-function type: {self:?}",);
         }
     }
 

--- a/src/types/type_id.rs
+++ b/src/types/type_id.rs
@@ -278,7 +278,7 @@ impl TypeId {
                     }
 
                     if resolved_generics.iter().any(|t| t.is_generic(types)) {
-                        let t = Type::GenericRecordInstance { base:  self.clone(), base_generics: generics.clone(), alias_list: resolved_generics, members, kind };
+                        let t = Type::GenericRecordInstance { base:  self.clone(), base_generics: generics, alias_list: resolved_generics, members, kind };
 
                         let tid = t.id();
                         types.insert(tid.clone(), t);

--- a/src/types/type_id.rs
+++ b/src/types/type_id.rs
@@ -244,6 +244,8 @@ impl TypeId {
         map: &HashMap<TypeId, TypeId>,
         types: &mut TypeMap,
     ) -> Result<TypeId, HayError> {
+        assert!(map.values().all(|t| !t.is_generic(types)), "{token}: TypeId::assign expects that all mapped values are concrete.");
+        
         // If the TypeId is in the map return the concrete type.
         if let Some(new_t) = map.get(self) {
             return Ok(new_t.clone());


### PR DESCRIPTION
This add initial support for blanket implementations

For example:
```
interface Print<T> {
    fn print(T)
}

impl<T> Print<&T>
requires: [Print<T>] {
    fn print(&T) {@ print }
}
```