### PR TITLE
Check for reimpl

### DIFF
--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -166,4 +166,9 @@ mod tests {
     fn blanket_impl_requirement_breach() -> Result<(), std::io::Error> {
         crate::compiler::test_tools::run_test("stmt", "blanket_impl_requirement_breach")
     }
+
+    #[test]
+    fn interface_rimpl() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test("stmt", "interface_reimpl")
+    }
 }

--- a/src/ast/stmt/impl.rs
+++ b/src/ast/stmt/impl.rs
@@ -368,8 +368,8 @@ impl InterfaceImplStmt {
             .collect();
         let instance_types = interface
             .types
-            .iter()
-            .map(|(tid, _)| map.get(tid).unwrap().clone())
+            .keys()
+            .map(|tid| map.get(tid).unwrap().clone())
             .collect();
 
         let instance_typ = Type::InterfaceInstance(InterfaceInstanceType {

--- a/src/ast/stmt/impl.rs
+++ b/src/ast/stmt/impl.rs
@@ -59,6 +59,7 @@ impl InterfaceImplStmt {
             }
             _ => unreachable!(),
         };
+
         let interface_tid = TypeId::new(base);
         let interface = match types.get(&interface_tid) {
             Some(Type::InterfaceBase(base)) => base.clone(),
@@ -140,6 +141,14 @@ impl InterfaceImplStmt {
             }
 
             return Err(err);
+        }
+
+        // Check that another implementation with the same __Annotations__ isn't already implemented.
+        if let Ok(reimpl) = interface.find_impl(&self.interface, &map) {
+            return Err(HayError::new(
+                format!("Interface {reimpl} has already been implemented"),
+                self.interface.loc,
+            ));
         }
 
         if let Some(requirements) = &interface.requires {
@@ -352,6 +361,17 @@ impl InterfaceImplStmt {
             return Err(err);
         }
 
+        let mapping = interface
+            .annotations
+            .iter()
+            .map(|t| map.get(t).unwrap().clone())
+            .collect();
+        let instance_types = interface
+            .types
+            .iter()
+            .map(|(tid, _)| map.get(tid).unwrap().clone())
+            .collect();
+
         let instance_typ = Type::InterfaceInstance(InterfaceInstanceType {
             token: Token {
                 kind: self.interface.kind.clone(),
@@ -359,7 +379,8 @@ impl InterfaceImplStmt {
                 loc: self.interface.loc,
             },
             base: interface_tid.clone(),
-            mapping: mapped,
+            mapping,
+            types: instance_types,
             fns_map,
             generics: self.generics.map(|generics| {
                 generics

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -311,4 +311,9 @@ mod functional {
     fn blanket_impl() -> Result<(), std::io::Error> {
         super::test_tools::run_test("functional", "blanket_impl")
     }
+
+    #[test]
+    fn blanket_impl_override() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test("functional", "blanket_impl_override")
+    }
 }

--- a/src/tests/functional/blanket_impl_override.hay
+++ b/src/tests/functional/blanket_impl_override.hay
@@ -1,0 +1,38 @@
+include "std.hay"
+include "opt.hay"
+include "vec.hay"
+
+interface MyPrint<T> {
+    fn my_print(T)
+    fn my_println(T) { my_print "\n" my_print}
+}
+
+impl MyPrint<Str> {
+    fn my_print(Str) { print }
+}
+
+impl MyPrint<u64> {
+    fn my_print(u64) { print }
+}
+
+impl<T> MyPrint<&T>
+requires: [MyPrint<T>] {
+    fn my_print(&T) { @ my_print }
+}
+
+impl MyPrint<&u64> {
+    fn my_print(&u64) { @ my_println "Inside override" my_print }
+}
+
+fn main() {
+
+    "Hello world!" my_println
+    12345          my_println
+
+    54321 "Hello Print!" as [x y]
+    &x             my_println
+    &y             my_println
+
+    Vec.new::<u64> as [mut v]
+
+}

--- a/src/tests/functional/blanket_impl_override.try_com
+++ b/src/tests/functional/blanket_impl_override.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/functional/blanket_impl_override.asm\n[CMD]: ld -o blanket_impl_override src/tests/functional/blanket_impl_override.o\n",
+  "stderr": ""
+}

--- a/src/tests/functional/blanket_impl_override.try_run
+++ b/src/tests/functional/blanket_impl_override.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "Hello world!\n12345\n54321\nInside override\nHello Print!\n",
+  "stderr": ""
+}

--- a/src/tests/stmt/interface_reimpl.hay
+++ b/src/tests/stmt/interface_reimpl.hay
@@ -1,0 +1,16 @@
+interface Foo<T> {
+    _: Output
+    fn foo(T) -> [Output]
+}
+
+impl Foo<u64> {
+    u64: Output
+    fn foo(u64) -> [u64] {}
+}
+
+// Error: Cannot implement Foo<u64> multiple times.
+impl Foo<u64> {
+    // Associated types should not be take into account while checking
+    bool: Output
+    fn foo(u64) -> [bool] { 10 > } 
+}

--- a/src/tests/stmt/interface_reimpl.try_com
+++ b/src/tests/stmt/interface_reimpl.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 1,
+  "stdout": "",
+  "stderr": "[src/tests/stmt/interface_reimpl.hay:12:6] Error: Interface Foo<u64> has already been implemented\n"
+}


### PR DESCRIPTION
Fixes #117 

Blanket impls also now default to an existing concrete implementation. Thus blanket impls, no longer generate a ton of the same implementation when monomorphized.  Additionally, this means that you can override a custom impl. We'll need to wait and see if this is desirable behaviour, but for now i'm fine with it. 