### PR TITLE
Unpack Expression

### DIFF
--- a/src/ast/expr/expr_typ.rs
+++ b/src/ast/expr/expr_typ.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use super::{
     AccessorExpr, AnnotatedCallExpr, AsExpr, ExprCast, ExprIdent, ExprIf, ExprLiteral,
     ExprOperator, ExprReturn, ExprSizeOf, ExprSyscall, ExprUnary, ExprVar, ExprWhile, MatchExpr,
-    NeverExpr, TupleExpr,
+    NeverExpr, TupleExpr, UnpackExpr,
 };
 
 /// Haystack's Expression Representation
@@ -51,6 +51,7 @@ pub enum Expr {
     Return(ExprReturn),
     Match(MatchExpr),
     Never(NeverExpr),
+    Unpack(UnpackExpr),
 }
 
 impl Expr {
@@ -73,6 +74,7 @@ impl Expr {
             | Expr::Return(ExprReturn { token })
             | Expr::Match(MatchExpr { token, .. })
             | Expr::Never(NeverExpr { token })
+            | Expr::Unpack(UnpackExpr { token })
             | Expr::Unary(ExprUnary {
                 op: ExprOperator { token, .. },
                 ..
@@ -118,6 +120,7 @@ impl Expr {
             Expr::Return(e) => e.type_check(stack, func),
             Expr::Match(e) => e.type_check(stack, frame, func, global_env, types, generic_map),
             Expr::Never(e) => e.type_check(stack),
+            Expr::Unpack(e) => e.type_check(stack, types),
         }
     }
 }
@@ -135,6 +138,9 @@ pub enum TypedExpr {
         n: usize,
     },
     Cast {
+        typ: TypeId,
+    },
+    Unpack {
         typ: TypeId,
     },
     CastEnumStruct {

--- a/src/ast/expr/mod.rs
+++ b/src/ast/expr/mod.rs
@@ -603,4 +603,14 @@ mod tests {
     fn destructure_non_tuple() -> Result<(), std::io::Error> {
         crate::compiler::test_tools::run_test("src/tests/type_check", "destructure_non_tuple", None)
     }
+
+    #[test]
+    fn unpack_non_tuple() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test("src/tests/type_check", "unpack_non_tuple", None)
+    }
+
+    #[test]
+    fn unpack_empty_stack() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test("src/tests/type_check", "unpack_empty_stack", None)
+    }
 }

--- a/src/ast/expr/mod.rs
+++ b/src/ast/expr/mod.rs
@@ -14,6 +14,7 @@ mod size_of;
 mod syscall;
 mod tuple;
 mod unary;
+mod unpack;
 mod var;
 mod r#while;
 
@@ -34,6 +35,7 @@ pub use size_of::*;
 pub use syscall::*;
 pub use tuple::*;
 pub use unary::*;
+pub use unpack::*;
 pub use var::*;
 
 mod tests {

--- a/src/ast/expr/unpack.rs
+++ b/src/ast/expr/unpack.rs
@@ -1,0 +1,36 @@
+use crate::{
+    error::HayError,
+    lex::token::Token,
+    types::{Stack, Type, TypeMap},
+};
+
+use super::TypedExpr;
+
+#[derive(Debug, Clone)]
+pub struct UnpackExpr {
+    pub token: Token,
+}
+
+impl UnpackExpr {
+    pub fn type_check(&self, stack: &mut Stack, types: &TypeMap) -> Result<TypedExpr, HayError> {
+        let typ =
+            match stack.pop() {
+                Some(t) => t,
+                None => return Err(HayError::new(
+                    "`Unpack` expression requires a tuple on top of the stack, but stack was empty",
+                    self.token.loc.clone(),
+                )),
+            };
+
+        if let Some(Type::Tuple { inner }) = types.get(&typ) {
+            inner.iter().for_each(|t| stack.push(t.clone()));
+        } else {
+            return Err(HayError::new(
+                format!("`Unpack` expression requires a tuple on top of the stack, found `{typ}` instead."), 
+                self.token.loc.clone()
+            ));
+        }
+
+        Ok(TypedExpr::Unpack { typ })
+    }
+}

--- a/src/ast/parser.rs
+++ b/src/ast/parser.rs
@@ -8,7 +8,7 @@ use std::collections::{HashSet};
 use super::arg::{IdentArg, UntypedArg, IdentArgKind};
 use super::expr::{
     AccessorExpr, AnnotatedCallExpr, AsExpr, ExprCast, ExprElseIf, ExprIdent, ExprIf, ExprLiteral,
-    ExprOperator, ExprReturn, ExprSizeOf, ExprSyscall, ExprUnary, ExprVar, ExprWhile, TupleExpr, MatchExpr, MatchElseExpr,
+    ExprOperator, ExprReturn, ExprSizeOf, ExprSyscall, ExprUnary, ExprVar, ExprWhile, TupleExpr, MatchExpr, MatchElseExpr, UnpackExpr,
 };
 use super::member::UntypedMember;
 use super::stmt::{RecordStmt, EnumStmt, FunctionStmt, FunctionStubStmt, InterfaceStmt, InterfaceImplStmt, VarStmt, PreDeclarationStmt};
@@ -1080,7 +1080,9 @@ impl<'a> Parser<'a> {
             TokenKind::Keyword(Keyword::SizeOf) => self.size_of(token),
             TokenKind::Keyword(Keyword::Return) => Ok(Box::new(Expr::Return(ExprReturn { token }))),
             TokenKind::Keyword(Keyword::Match) => self.match_expr(token),
+            TokenKind::Keyword(Keyword::Unpack) => Ok(Box::new(Expr::Unpack(UnpackExpr { token}))),
             TokenKind::Marker(Marker::LeftBracket) => self.parse_tuple_expr(token),
+            
             kind => Err(HayError::new(
                 format!("Not sure how to parse expression from {kind} yet"),
                 token.loc,

--- a/src/backend/instruction.rs
+++ b/src/backend/instruction.rs
@@ -478,7 +478,7 @@ impl Instruction {
                     });
                 }
             }
-            TypedExpr::Cast { .. } => (),
+            TypedExpr::Cast { .. } | TypedExpr::Unpack { .. } => (),
             TypedExpr::CastEnumStruct { idx, padding, .. } => {
                 for _ in 0..padding {
                     ops.push(Instruction::PushU64(0));

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -449,6 +449,11 @@ mod functional {
     fn tuple_destructure() -> Result<(), std::io::Error> {
         crate::compiler::test_tools::run_test("src/tests/functional", "tuple_destructure", None)
     }
+
+    #[test]
+    fn unpack_tuple() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test("src/tests/functional", "unpack_tuple", None)
+    }
 }
 
 mod examples {

--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -177,6 +177,7 @@ pub enum Keyword {
     Interface,
     Requires,
     Match,
+    Unpack,
 }
 
 impl std::fmt::Display for Keyword {
@@ -203,6 +204,7 @@ impl std::fmt::Display for Keyword {
             Keyword::Interface => write!(f, "interface")?,
             Keyword::Requires => write!(f, "requires")?,
             Keyword::Match => write!(f, "match")?,
+            Keyword::Unpack => write!(f, "unpack")?,
         }
         write!(f, "`")
     }
@@ -231,6 +233,7 @@ impl Keyword {
         map.insert("interface", TokenKind::Keyword(Keyword::Interface));
         map.insert("requires", TokenKind::Keyword(Keyword::Requires));
         map.insert("match", TokenKind::Keyword(Keyword::Match));
+        map.insert("unpack", TokenKind::Keyword(Keyword::Unpack));
 
         map.insert("true", TokenKind::Literal(Literal::Bool(true)));
         map.insert("false", TokenKind::Literal(Literal::Bool(false)));

--- a/src/tests/functional/unpack_tuple.hay
+++ b/src/tests/functional/unpack_tuple.hay
@@ -1,0 +1,6 @@
+fn main() {
+    [1 true "Three"] unpack 
+    println
+    println
+    println
+}

--- a/src/tests/functional/unpack_tuple.try_com
+++ b/src/tests/functional/unpack_tuple.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/functional/unpack_tuple.asm\n[CMD]: ld -o unpack_tuple src/tests/functional/unpack_tuple.o\n",
+  "stderr": ""
+}

--- a/src/tests/functional/unpack_tuple.try_run
+++ b/src/tests/functional/unpack_tuple.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "Three\ntrue\n1\n",
+  "stderr": ""
+}

--- a/src/tests/type_check/unpack_empty_stack.hay
+++ b/src/tests/type_check/unpack_empty_stack.hay
@@ -1,0 +1,3 @@
+fn main() {
+    unpack
+}

--- a/src/tests/type_check/unpack_empty_stack.try_com
+++ b/src/tests/type_check/unpack_empty_stack.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 1,
+  "stdout": "",
+  "stderr": "[src/tests/type_check/unpack_empty_stack.hay:2:5] Error: `Unpack` expression requires a tuple on top of the stack, but stack was empty\n"
+}

--- a/src/tests/type_check/unpack_non_tuple.hay
+++ b/src/tests/type_check/unpack_non_tuple.hay
@@ -1,0 +1,3 @@
+fn main() {
+    "Hello World" unpack
+}

--- a/src/tests/type_check/unpack_non_tuple.try_com
+++ b/src/tests/type_check/unpack_non_tuple.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 1,
+  "stdout": "",
+  "stderr": "[src/tests/type_check/unpack_non_tuple.hay:2:19] Error: `Unpack` expression requires a tuple on top of the stack, found `Str` instead.\n"
+}


### PR DESCRIPTION
Adds support for anonymous tuple destructuring with the `unpack` keyword.
```
fn main() {
    [1 true "Three"] unpack 
    println // prints `Three`
    println // prints `true`
    println // prints `1`
}
```