### PR TITLE
Anonymous Structures

### DIFF
--- a/src/ast/expr/annotated_call.rs
+++ b/src/ast/expr/annotated_call.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::{arg::UntypedArg, stmt::StmtKind},
     error::HayError,
     lex::token::Token,
-    types::{Signature, Stack, TypeId, TypeMap},
+    types::{Signature, Stack, TypeId, TypeMap, Variance},
 };
 
 use super::TypedExpr;
@@ -139,7 +139,9 @@ impl AnnotatedCallExpr {
 
         // Check and update the stack and frame.
         sig.assign(&self.token, &annotations, types)?;
-        assert!(sig.evaluate(&self.token, stack, types)?.is_none());
+        assert!(sig
+            .evaluate(&self.token, stack, types, Variance::Covariant)?
+            .is_none());
 
         Ok(TypedExpr::Call { func: tid.0 })
     }

--- a/src/ast/expr/as.rs
+++ b/src/ast/expr/as.rs
@@ -125,7 +125,10 @@ impl AsExpr {
                     typed_args.push(t);
                 }
                 IdentArgKind::Tuple { args } => match types.get(&t) {
-                    Some(Type::Tuple { inner }) => {
+                    Some(Type::Tuple {
+                        inner,
+                        idents: None,
+                    }) => {
                         if args.len() != inner.len() {
                             return Err(HayError::new_type_err(
                                 "Incorrect number of arguments to destructure tuple",
@@ -148,6 +151,10 @@ impl AsExpr {
                             frame,
                         )?;
                     }
+                    Some(Type::Tuple {
+                        inner: _,
+                        idents: Some(_),
+                    }) => todo!(),
                     _ => {
                         return Err(HayError::new_type_err(
                             format!("Non-tuple type `{t}` cannot be destructured"),

--- a/src/ast/expr/as.rs
+++ b/src/ast/expr/as.rs
@@ -125,10 +125,7 @@ impl AsExpr {
                     typed_args.push(t);
                 }
                 IdentArgKind::Tuple { args } => match types.get(&t) {
-                    Some(Type::Tuple {
-                        inner,
-                        idents: None,
-                    }) => {
+                    Some(Type::Tuple { inner, .. }) => {
                         if args.len() != inner.len() {
                             return Err(HayError::new_type_err(
                                 "Incorrect number of arguments to destructure tuple",
@@ -151,10 +148,6 @@ impl AsExpr {
                             frame,
                         )?;
                     }
-                    Some(Type::Tuple {
-                        inner: _,
-                        idents: Some(_),
-                    }) => todo!(),
                     _ => {
                         return Err(HayError::new_type_err(
                             format!("Non-tuple type `{t}` cannot be destructured"),

--- a/src/ast/expr/cast.rs
+++ b/src/ast/expr/cast.rs
@@ -78,6 +78,7 @@ impl ExprCast {
 
                     Err(e)
                 }
+                RecordKind::Tuple => unreachable!(),
                 RecordKind::Interface => unreachable!(),
             },
             Type::U64 => {
@@ -131,7 +132,7 @@ impl ExprCast {
                 )?;
                 Ok(TypedExpr::Cast { typ: typ_id })
             }
-            Type::Tuple { inner } => {
+            Type::Tuple { inner, .. } => {
                 Signature::new(inner.clone(), vec![typ_id.clone()]).evaluate(
                     &self.token,
                     stack,
@@ -194,6 +195,7 @@ impl ExprCast {
                         return Err(e);
                     }
                     RecordKind::Interface => unreachable!(),
+                    RecordKind::Tuple => unreachable!(),
                 };
 
                 Ok(TypedExpr::Cast { typ: tid })

--- a/src/ast/expr/cast.rs
+++ b/src/ast/expr/cast.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     error::HayError,
     lex::token::Token,
-    types::{RecordKind, Signature, Stack, Type, TypeId, TypeMap, VariantType},
+    types::{RecordKind, Signature, Stack, Type, TypeId, TypeMap, Variance, VariantType},
 };
 
 use super::TypedExpr;
@@ -50,7 +50,12 @@ impl ExprCast {
                         members.iter().map(|m| m.typ.clone()).collect(),
                         vec![typ_id.clone()],
                     )
-                    .evaluate(&self.token, stack, types)?;
+                    .evaluate(
+                        &self.token,
+                        stack,
+                        types,
+                        Variance::Covariant,
+                    )?;
                     Ok(TypedExpr::Cast { typ: typ_id })
                 }
                 RecordKind::Union => {
@@ -61,7 +66,13 @@ impl ExprCast {
                     });
 
                     let padding = typ_id.size(types)? - stack.iter().last().unwrap().size(types)?;
-                    Signature::evaluate_many(&sigs, &self.token, stack, types)?;
+                    Signature::evaluate_many(
+                        &sigs,
+                        &self.token,
+                        stack,
+                        types,
+                        Variance::Covariant,
+                    )?;
 
                     Ok(TypedExpr::Pad { padding })
                 }
@@ -102,6 +113,7 @@ impl ExprCast {
                     &self.token,
                     stack,
                     types,
+                    Variance::Covariant,
                 )?;
                 Ok(TypedExpr::Cast { typ: typ_id })
             }
@@ -116,6 +128,7 @@ impl ExprCast {
                     &self.token,
                     stack,
                     types,
+                    Variance::Variant,
                 )?;
                 Ok(TypedExpr::Cast { typ: typ_id })
             }
@@ -129,6 +142,7 @@ impl ExprCast {
                     &self.token,
                     stack,
                     types,
+                    Variance::Variant,
                 )?;
                 Ok(TypedExpr::Cast { typ: typ_id })
             }
@@ -137,6 +151,7 @@ impl ExprCast {
                     &self.token,
                     stack,
                     types,
+                    Variance::Variant,
                 )?;
 
                 Ok(TypedExpr::Cast { typ: typ_id })
@@ -146,6 +161,7 @@ impl ExprCast {
                     &self.token,
                     stack,
                     types,
+                    Variance::Covariant,
                 )?;
                 Ok(TypedExpr::Cast { typ: typ_id })
             }
@@ -162,7 +178,12 @@ impl ExprCast {
                             vec![typ_id.clone()],
                             generics.clone(),
                         )
-                        .evaluate(&self.token, stack, types)?;
+                        .evaluate(
+                            &self.token,
+                            stack,
+                            types,
+                            Variance::Covariant,
+                        )?;
                         typ_id
                     }
                     RecordKind::Union => {
@@ -177,7 +198,13 @@ impl ExprCast {
                             })
                             .collect::<Vec<Signature>>();
 
-                        Signature::evaluate_many(&sigs, &self.token, stack, types)?;
+                        Signature::evaluate_many(
+                            &sigs,
+                            &self.token,
+                            stack,
+                            types,
+                            Variance::Variant,
+                        )?;
 
                         typ_id
                     }
@@ -227,7 +254,7 @@ impl ExprCast {
                         let signature =
                             Signature::new(vec![member.typ.clone()], vec![typ_id.clone()]);
 
-                        signature.evaluate(&self.token, stack, types)?;
+                        signature.evaluate(&self.token, stack, types, Variance::Covariant)?;
 
                         Ok(TypedExpr::CastEnumStruct { padding, idx })
                     }
@@ -249,14 +276,15 @@ impl ExprCast {
                             generics.clone(),
                         );
 
-                        let padding =
-                            if let Some(map) = signature.evaluate(&self.token, stack, types)? {
-                                stack.last().unwrap().size(types)?
-                                    - 1
-                                    - member.typ.assign(&self.token, &map, types)?.size(types)?
-                            } else {
-                                stack.last().unwrap().size(types)? - 1 - member.typ.size(types)?
-                            };
+                        let padding = if let Some(map) =
+                            signature.evaluate(&self.token, stack, types, Variance::Covariant)?
+                        {
+                            stack.last().unwrap().size(types)?
+                                - 1
+                                - member.typ.assign(&self.token, &map, types)?.size(types)?
+                        } else {
+                            stack.last().unwrap().size(types)? - 1 - member.typ.size(types)?
+                        };
 
                         Ok(TypedExpr::CastEnumStruct { padding, idx })
                     }

--- a/src/ast/expr/ident.rs
+++ b/src/ast/expr/ident.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::stmt::StmtKind,
     error::HayError,
     lex::token::Token,
-    types::{Frame, Signature, Stack, Type, TypeId, TypeMap},
+    types::{Frame, Signature, Stack, Type, TypeId, TypeMap, Variance},
 };
 
 use super::TypedExpr;
@@ -24,7 +24,9 @@ impl ExprIdent {
     ) -> Result<TypedExpr, HayError> {
         match global_env.get(&self.ident.lexeme) {
             Some((StmtKind::Function, sig)) => {
-                let typed_expr = if let Some(map) = sig.evaluate(&self.ident, stack, types)? {
+                let typed_expr = if let Some(map) =
+                    sig.evaluate(&self.ident, stack, types, Variance::Covariant)?
+                {
                     let gen_fn_tid = TypeId::new(&self.ident.lexeme);
                     let monomorphised = gen_fn_tid.assign(&self.ident, &map, types)?;
                     Ok(TypedExpr::Call {
@@ -39,7 +41,7 @@ impl ExprIdent {
                 return typed_expr;
             }
             Some((StmtKind::Var, sig)) => {
-                sig.evaluate(&self.ident, stack, types)?;
+                sig.evaluate(&self.ident, stack, types, Variance::Variant)?;
                 return Ok(TypedExpr::Global {
                     ident: self.ident.lexeme,
                 });

--- a/src/ast/expr/if.rs
+++ b/src/ast/expr/if.rs
@@ -4,7 +4,7 @@ use crate::{
     ast::stmt::StmtKind,
     error::HayError,
     lex::token::Token,
-    types::{Frame, Signature, Stack, Type, TypeId, TypeMap, UncheckedFunction},
+    types::{Frame, Signature, Stack, Type, TypeId, TypeMap, UncheckedFunction, Variance},
 };
 
 use super::{Expr, TypedExpr};
@@ -32,7 +32,7 @@ impl ExprIf {
         generic_map: &Option<HashMap<TypeId, TypeId>>,
     ) -> Result<TypedExpr, HayError> {
         let sig = Signature::new(vec![Type::Bool.id()], vec![]);
-        sig.evaluate(&self.token, stack, types)?;
+        sig.evaluate(&self.token, stack, types, Variance::Variant)?;
         let initial_frame = frame.clone();
         let mut otherwise_stack = stack.clone();
 
@@ -181,7 +181,12 @@ impl ExprElseIf {
             )?);
         }
 
-        Signature::new(vec![Type::Bool.id()], vec![]).evaluate(&self.token, stack, types)?;
+        Signature::new(vec![Type::Bool.id()], vec![]).evaluate(
+            &self.token,
+            stack,
+            types,
+            Variance::Variant,
+        )?;
 
         let stack_after_check = stack.clone();
 

--- a/src/ast/expr/mod.rs
+++ b/src/ast/expr/mod.rs
@@ -613,4 +613,22 @@ mod tests {
     fn unpack_empty_stack() -> Result<(), std::io::Error> {
         crate::compiler::test_tools::run_test("src/tests/type_check", "unpack_empty_stack", None)
     }
+
+    #[test]
+    fn anon_struct_bad_accessor1() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test(
+            "src/tests/type_check",
+            "anon_struct_bad_accessor1",
+            None,
+        )
+    }
+
+    #[test]
+    fn anon_struct_bad_accessor2() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test(
+            "src/tests/type_check",
+            "anon_struct_bad_accessor2",
+            None,
+        )
+    }
 }

--- a/src/ast/expr/operator.rs
+++ b/src/ast/expr/operator.rs
@@ -2,7 +2,7 @@ use crate::{
     ast::stmt::{GlobalEnv, StmtKind},
     error::HayError,
     lex::token::{Operator, Token},
-    types::{Signature, Stack, Type, TypeId, TypeMap},
+    types::{Signature, Stack, Type, TypeId, TypeMap, Variance},
 };
 
 use super::{ExprIdent, TypedExpr};
@@ -19,9 +19,10 @@ impl ExprOperator {
         types: &mut TypeMap,
         global_env: &mut GlobalEnv,
         default_sig: Signature,
+        default_variance: Variance,
         interface_fn_name: String,
     ) -> Result<TypedExpr, HayError> {
-        match default_sig.evaluate(&self.token, stack, types) {
+        match default_sig.evaluate(&self.token, stack, types, default_variance) {
             Ok(_) => Ok(TypedExpr::Operator {
                 op: self.op,
                 typ: None,
@@ -67,6 +68,7 @@ impl ExprOperator {
                 types,
                 global_env,
                 Signature::new(vec![Type::U64.id(), Type::U64.id()], vec![Type::U64.id()]),
+                Variance::Variant,
                 String::from("Op.add"),
             ),
             Operator::Minus => self.type_check_interface_op(
@@ -74,6 +76,7 @@ impl ExprOperator {
                 types,
                 global_env,
                 Signature::new(vec![Type::U64.id(), Type::U64.id()], vec![Type::U64.id()]),
+                Variance::Variant,
                 String::from("Op.sub"),
             ),
             Operator::Star => self.type_check_interface_op(
@@ -81,6 +84,7 @@ impl ExprOperator {
                 types,
                 global_env,
                 Signature::new(vec![Type::U64.id(), Type::U64.id()], vec![Type::U64.id()]),
+                Variance::Variant,
                 String::from("Op.mul"),
             ),
             Operator::Slash => self.type_check_interface_op(
@@ -88,6 +92,7 @@ impl ExprOperator {
                 types,
                 global_env,
                 Signature::new(vec![Type::U64.id(), Type::U64.id()], vec![Type::U64.id()]),
+                Variance::Variant,
                 String::from("Op.div"),
             ),
             Operator::Ampersand => self.type_check_interface_op(
@@ -95,6 +100,7 @@ impl ExprOperator {
                 types,
                 global_env,
                 Signature::new(vec![Type::U64.id(), Type::U64.id()], vec![Type::U64.id()]),
+                Variance::Variant,
                 String::from("Op.and"),
             ),
             Operator::Pipe => self.type_check_interface_op(
@@ -102,6 +108,7 @@ impl ExprOperator {
                 types,
                 global_env,
                 Signature::new(vec![Type::U64.id(), Type::U64.id()], vec![Type::U64.id()]),
+                Variance::Variant,
                 String::from("Op.or"),
             ),
             Operator::Caret => self.type_check_interface_op(
@@ -109,6 +116,7 @@ impl ExprOperator {
                 types,
                 global_env,
                 Signature::new(vec![Type::U64.id(), Type::U64.id()], vec![Type::U64.id()]),
+                Variance::Variant,
                 String::from("Op.xor"),
             ),
             Operator::ShiftLeft => self.type_check_interface_op(
@@ -116,6 +124,7 @@ impl ExprOperator {
                 types,
                 global_env,
                 Signature::new(vec![Type::U64.id(), Type::U8.id()], vec![Type::U64.id()]),
+                Variance::Variant,
                 String::from("Op.shl"),
             ),
             Operator::ShiftRight => self.type_check_interface_op(
@@ -123,6 +132,7 @@ impl ExprOperator {
                 types,
                 global_env,
                 Signature::new(vec![Type::U64.id(), Type::U8.id()], vec![Type::U64.id()]),
+                Variance::Variant,
                 String::from("Op.shr"),
             ),
             Operator::LessThan
@@ -139,11 +149,7 @@ impl ExprOperator {
                         vec![Type::Bool.id()],
                     ),
                 ];
-
-                // TODO: Comparison between pointers
-
-                Signature::evaluate_many(&sigs, &self.token, stack, types)?;
-
+                Signature::evaluate_many(&sigs, &self.token, stack, types, Variance::Variant)?;
                 Ok(TypedExpr::Operator {
                     op: self.op,
                     typ: None,
@@ -201,6 +207,7 @@ impl ExprOperator {
                     &self.token,
                     stack,
                     types,
+                    Variance::Covariant,
                 )?;
 
                 Ok(TypedExpr::Operator {
@@ -246,6 +253,7 @@ impl ExprOperator {
                     &self.token,
                     stack,
                     types,
+                    Variance::Covariant,
                 )?;
 
                 Ok(TypedExpr::Operator {
@@ -262,6 +270,7 @@ impl ExprOperator {
                     &self.token,
                     stack,
                     types,
+                    Variance::Variant,
                 )?;
 
                 Ok(TypedExpr::Operator {
@@ -286,6 +295,7 @@ impl ExprOperator {
                     &self.token,
                     stack,
                     types,
+                    Variance::Covariant,
                 )?
                 .unwrap();
 
@@ -300,7 +310,7 @@ impl ExprOperator {
                     vec![],
                     vec![TypeId::new("T")],
                 )
-                .evaluate(&self.token, stack, types)?
+                .evaluate(&self.token, stack, types, Variance::Variant)?
                 .unwrap();
 
                 Ok(TypedExpr::Operator {

--- a/src/ast/expr/size_of.rs
+++ b/src/ast/expr/size_of.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use crate::{
     error::HayError,
     lex::token::{Literal, Token},
-    types::{Signature, Stack, Type, TypeId, TypeMap},
+    types::{Signature, Stack, Type, TypeId, TypeMap, Variance},
 };
 
 use super::TypedExpr;
@@ -47,7 +47,12 @@ impl ExprSizeOf {
             },
         };
 
-        Signature::new(vec![], vec![Type::U64.id()]).evaluate(&self.token, stack, types)?;
+        Signature::new(vec![], vec![Type::U64.id()]).evaluate(
+            &self.token,
+            stack,
+            types,
+            Variance::Variant,
+        )?;
         Ok(TypedExpr::Literal {
             value: Literal::U64((tid.size(types)? * tid.width()) as u64),
         })

--- a/src/ast/expr/syscall.rs
+++ b/src/ast/expr/syscall.rs
@@ -1,7 +1,7 @@
 use crate::{
     error::HayError,
     lex::token::Token,
-    types::{Signature, Stack, Type, TypeMap},
+    types::{Signature, Stack, Type, TypeMap, Variance},
 };
 
 use super::TypedExpr;
@@ -26,7 +26,12 @@ impl ExprSyscall {
             ));
         }
 
-        Signature::new(vec![Type::U64.id()], vec![]).evaluate(&self.token, stack, types)?;
+        Signature::new(vec![Type::U64.id()], vec![]).evaluate(
+            &self.token,
+            stack,
+            types,
+            Variance::Variant,
+        )?;
 
         for _ in 0..self.n {
             let t = stack.pop().unwrap();

--- a/src/ast/expr/tuple.rs
+++ b/src/ast/expr/tuple.rs
@@ -58,6 +58,7 @@ impl TupleExpr {
 
         let tuple = Type::Tuple {
             inner: inner_stack.clone(),
+            idents: None,
         };
 
         let tid = tuple.id();

--- a/src/ast/expr/unary.rs
+++ b/src/ast/expr/unary.rs
@@ -74,7 +74,7 @@ impl ExprUnary {
                                 {
                                     if !m.is_public() {
                                         match &func.impl_on {
-                                    Some(typ) => if &m.parent != typ {
+                                    Some(typ) => if m.parent.as_ref().unwrap() != typ {
                                         return Err(
                                             HayError::new_type_err(
                                                 format!("Cannot access {kind} `{}` member `{}` as it is declared as private.", name.lexeme, m.ident.lexeme),
@@ -101,6 +101,7 @@ impl ExprUnary {
                                                 RecordKind::Struct => "Struct",
                                                 RecordKind::EnumStruct => "Enum struct",
                                                 RecordKind::Interface => unreachable!(),
+                                                RecordKind::Tuple => unreachable!(),
                                             },
                                             name.lexeme,
                                             inner_member.lexeme,

--- a/src/ast/expr/unpack.rs
+++ b/src/ast/expr/unpack.rs
@@ -22,7 +22,7 @@ impl UnpackExpr {
                 )),
             };
 
-        if let Some(Type::Tuple { inner }) = types.get(&typ) {
+        if let Some(Type::Tuple { inner, .. }) = types.get(&typ) {
             inner.iter().for_each(|t| stack.push(t.clone()));
         } else {
             return Err(HayError::new(

--- a/src/ast/expr/while.rs
+++ b/src/ast/expr/while.rs
@@ -4,7 +4,9 @@ use crate::{
     ast::stmt::StmtKind,
     error::HayError,
     lex::token::Token,
-    types::{Frame, FramedType, Signature, Stack, Type, TypeId, TypeMap, UncheckedFunction},
+    types::{
+        Frame, FramedType, Signature, Stack, Type, TypeId, TypeMap, UncheckedFunction, Variance,
+    },
 };
 
 use super::{Expr, TypedExpr};
@@ -60,7 +62,12 @@ impl ExprWhile {
             });
         }
 
-        Signature::new(vec![Type::Bool.id()], vec![]).evaluate(&self.token, stack, types)?;
+        Signature::new(vec![Type::Bool.id()], vec![]).evaluate(
+            &self.token,
+            stack,
+            types,
+            Variance::Variant,
+        )?;
 
         let stack_after_check = stack.clone();
 

--- a/src/ast/member.rs
+++ b/src/ast/member.rs
@@ -10,7 +10,7 @@ use super::visibility::Visitiliby;
 
 #[derive(Debug, Clone)]
 pub struct UntypedMember {
-    pub parent: Token,
+    pub parent: Option<Token>,
     pub vis: Visitiliby,
     pub token: Token,
     pub ident: Token,
@@ -25,7 +25,10 @@ impl UntypedMember {
         let mut out = vec![];
         for m in members {
             let typ = TypeId::from_token(&m.token, types, local_types)?;
-            let parent = TypeId::new(&m.parent.lexeme);
+            let parent = match &m.parent {
+                Some(parent) => Some(TypeId::new(&parent.lexeme)),
+                None => None,
+            };
             out.push(TypedMember {
                 parent,
                 vis: m.vis,
@@ -41,7 +44,7 @@ impl UntypedMember {
 
 #[derive(Debug, Clone)]
 pub struct TypedMember {
-    pub parent: TypeId,
+    pub parent: Option<TypeId>,
     pub vis: Visitiliby,
     pub token: Token,
     pub ident: Token,

--- a/src/backend/instruction.rs
+++ b/src/backend/instruction.rs
@@ -160,9 +160,11 @@ impl Instruction {
                                         &members[idx].typ
                                     }
                                     RecordKind::Interface => unreachable!(),
+                                    RecordKind::Tuple => unreachable!(),
                                 },
                                 Type::Tuple {
                                     inner: tuple_members,
+                                    idents: None,
                                 } => {
                                     let idx = inner
                                         .parse::<usize>()
@@ -170,6 +172,23 @@ impl Instruction {
                                     for m in &tuple_members[0..idx] {
                                         offset += m.size(types).unwrap()
                                     }
+                                    &tuple_members[idx]
+                                }
+                                Type::Tuple {
+                                    inner: tuple_members,
+                                    idents: Some(idents),
+                                } => {
+                                    let idx = idents
+                                        .iter()
+                                        .enumerate()
+                                        .find(|(_, id)| &id.lexeme == inner)
+                                        .unwrap()
+                                        .0;
+
+                                    for m in &tuple_members[0..idx] {
+                                        offset += m.size(types).unwrap()
+                                    }
+
                                     &tuple_members[idx]
                                 }
                                 _ => panic!("Didn't expect to find {typ} here!"),
@@ -224,6 +243,7 @@ impl Instruction {
                                 }
                                 RecordKind::EnumStruct => todo!(),
                                 RecordKind::Interface => unreachable!(),
+                                RecordKind::Tuple => unreachable!(),
                             }
                         } else {
                             panic!("{typ}");
@@ -280,6 +300,7 @@ impl Instruction {
                                 }
                                 RecordKind::EnumStruct => todo!(),
                                 RecordKind::Interface => unreachable!(),
+                                RecordKind::Tuple => unreachable!(),
                             }
                         } else {
                             panic!("{typ}");

--- a/src/compiler/mod.rs
+++ b/src/compiler/mod.rs
@@ -454,6 +454,11 @@ mod functional {
     fn unpack_tuple() -> Result<(), std::io::Error> {
         crate::compiler::test_tools::run_test("src/tests/functional", "unpack_tuple", None)
     }
+
+    #[test]
+    fn anonymous_structures() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test("src/tests/functional", "anonymous_structures", None)
+    }
 }
 
 mod examples {

--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -273,6 +273,7 @@ pub enum TypeToken {
     },
     Tuple {
         inner: Vec<Token>,
+        idents: Option<Vec<Token>>,
     },
 }
 
@@ -311,18 +312,38 @@ impl std::fmt::Display for TypeToken {
                     write!(f, "&{p}")
                 }
             }
-            TypeToken::Tuple { inner } => {
+            TypeToken::Tuple {
+                inner,
+                idents: None,
+            } => {
                 write!(f, "[")?;
                 if !inner.is_empty() {
                     for inner_t in inner.iter().take(inner.len() - 1) {
-                        write!(f, "{inner_t} ")?;
+                        write!(f, "{} ", inner_t.lexeme)?;
                     }
                 }
 
                 if let Some(last) = inner.last() {
-                    write!(f, "{last}")?;
+                    write!(f, "{}", last.lexeme)?;
                 }
                 write!(f, "]")
+            }
+            TypeToken::Tuple {
+                inner,
+                idents: Some(idents),
+            } => {
+                assert_eq!(inner.len(), idents.len());
+                write!(f, "{{")?;
+                if !inner.is_empty() {
+                    for (inner_t, ident) in inner.iter().zip(idents.iter()).take(inner.len() - 1) {
+                        write!(f, "{}: {} ", inner_t.lexeme, ident.lexeme)?;
+                    }
+                }
+
+                if let (Some(last_t), Some(last_id)) = (inner.last(), idents.last()) {
+                    write!(f, "{}: {}", last_t.lexeme, last_id.lexeme)?;
+                }
+                write!(f, "}}")
             }
         }
     }

--- a/src/tests/functional/anonymous_structures.hay
+++ b/src/tests/functional/anonymous_structures.hay
@@ -1,0 +1,52 @@
+enum struct Foo {
+    u64            : Value
+    [u64 u64]      : Tuple
+    {u64: x u64: y}: NamedTuple
+}
+
+impl Print<Foo> {
+    fn print(Foo) {
+        match {
+            Foo::Value as [value] { 
+                "Foo::Value(" print value print ")" print
+            }
+            Foo::Tuple as [tuple] { 
+                "Foo::Tuple" print 
+                "[" print tuple::0 print
+                " " print tuple::1 print
+                "]" print
+            }
+            Foo::NamedTuple as [named] { 
+                "Foo::Named {" print 
+                " x: " print named::x print
+                " y: " print named::y print
+                " }"   print
+            }
+        }
+    }
+}
+
+fn square_x({u64: x u64: y}: point) -> [[u64 u64]] {
+    [point::x point::x * point::y]
+}
+
+fn main() {
+    12345         cast(Foo::Value)      println 
+    [12345 54321] cast(Foo::Tuple)      println
+    [12345 54321] cast(Foo::NamedTuple) println
+
+    "a" "b" cast({Str: a Str: b}) as [x]
+    x::a println
+    x::b println
+
+    x as [[a b]]
+    a println
+    b println
+
+    x unpack println println 
+
+    x println
+
+    [3 4] square_x println
+
+}

--- a/src/tests/functional/anonymous_structures.try_com
+++ b/src/tests/functional/anonymous_structures.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "[CMD]: nasm -felf64 src/tests/functional/anonymous_structures.asm\n[CMD]: ld -o anonymous_structures src/tests/functional/anonymous_structures.o\n",
+  "stderr": ""
+}

--- a/src/tests/functional/anonymous_structures.try_run
+++ b/src/tests/functional/anonymous_structures.try_run
@@ -1,0 +1,5 @@
+{
+  "exit_code": 0,
+  "stdout": "Foo::Value(12345)\nFoo::Tuple[12345 54321]\nFoo::Named { x: 12345 y: 54321 }\na\nb\na\nb\nb\na\n[a b]\n[9 4]\n",
+  "stderr": ""
+}

--- a/src/tests/parser/parse_bad_interface_annotation_close.hay
+++ b/src/tests/parser/parse_bad_interface_annotation_close.hay
@@ -1,1 +1,1 @@
-interface Foo<A B C {}
+interface Foo<A B C

--- a/src/tests/parser/parse_bad_interface_annotation_close.try_com
+++ b/src/tests/parser/parse_bad_interface_annotation_close.try_com
@@ -1,5 +1,5 @@
 {
   "exit_code": 1,
   "stdout": "",
-  "stderr": "[src/tests/parser/parse_bad_interface_annotation_close.hay:1:21] Error: Expected `>` after function annotations, but found `{` instead.\n"
+  "stderr": "[src/tests/parser/parse_bad_interface_annotation_close.hay:1:19] Error: Expected `>` after function annotations, but found end of file instead.\n"
 }

--- a/src/tests/parser/parse_struct_bad_annotations_close.hay
+++ b/src/tests/parser/parse_struct_bad_annotations_close.hay
@@ -1,3 +1,1 @@
-struct foo<a b c {
-    
-}
+struct foo<a b c  

--- a/src/tests/parser/parse_struct_bad_annotations_close.try_com
+++ b/src/tests/parser/parse_struct_bad_annotations_close.try_com
@@ -1,5 +1,5 @@
 {
   "exit_code": 1,
   "stdout": "",
-  "stderr": "[src/tests/parser/parse_struct_bad_annotations_close.hay:1:18] Error: Expected `>` after `struct` generics, but found `{` instead.\n"
+  "stderr": "[src/tests/parser/parse_struct_bad_annotations_close.hay:1:18] Error: Expected `>` after `struct` generics, but found end of file instead.\n"
 }

--- a/src/tests/type_check/anon_struct_bad_accessor1.hay
+++ b/src/tests/type_check/anon_struct_bad_accessor1.hay
@@ -1,0 +1,4 @@
+fn main() {
+    1 cast({u64: n}) as [x]
+    x::0 println
+}

--- a/src/tests/type_check/anon_struct_bad_accessor1.try_com
+++ b/src/tests/type_check/anon_struct_bad_accessor1.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 1,
+  "stdout": "",
+  "stderr": "[src/tests/type_check/anon_struct_bad_accessor1.hay:3:5] Error: Expected one of [\"n\"] to access into `{u64: n}`, but found `u64` instead.\n"
+}

--- a/src/tests/type_check/anon_struct_bad_accessor2.hay
+++ b/src/tests/type_check/anon_struct_bad_accessor2.hay
@@ -1,0 +1,4 @@
+fn main() {
+    1 cast({u64: n}) as [x]
+    x::m println
+}

--- a/src/tests/type_check/anon_struct_bad_accessor2.try_com
+++ b/src/tests/type_check/anon_struct_bad_accessor2.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 1,
+  "stdout": "",
+  "stderr": "[src/tests/type_check/anon_struct_bad_accessor2.hay:3:5] Error: Expected one of [\"n\"] to access into `{u64: n}`, but found an identifier (m) instead.\n"
+}

--- a/src/types/interface/base.rs
+++ b/src/types/interface/base.rs
@@ -7,7 +7,7 @@ use crate::{
     },
     error::HayError,
     lex::token::{Token, TokenKind, TypeToken},
-    types::{Stack, Type, TypeId, TypeMap},
+    types::{Stack, Type, TypeId, TypeMap, Variance},
 };
 
 #[derive(Debug, Clone)]
@@ -123,13 +123,15 @@ impl InterfaceBaseType {
                 .unwrap_or_else(|| panic!("didn't find function: {mapped_fn}"))
             {
                 (StmtKind::Function, signature) => {
-                    if let Some(map) = match signature.evaluate(&expr.ident, stack, types) {
-                        Ok(map) => map,
-                        Err(_) => {
-                            *stack = stack_before.clone();
-                            continue;
+                    if let Some(map) =
+                        match signature.evaluate(&expr.ident, stack, types, Variance::Covariant) {
+                            Ok(map) => map,
+                            Err(_) => {
+                                *stack = stack_before.clone();
+                                continue;
+                            }
                         }
-                    } {
+                    {
                         let interface = match types.get(instance).unwrap() {
                             Type::InterfaceInstance(instance) => instance.clone(),
                             _ => unreachable!(),

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -5,6 +5,7 @@ mod record_kind;
 mod signature;
 mod r#type;
 mod type_id;
+mod variance;
 mod variant;
 
 pub use framed_type::*;
@@ -14,6 +15,7 @@ pub use r#type::*;
 pub use record_kind::*;
 pub use signature::*;
 pub use type_id::*;
+pub use variance::*;
 pub use variant::*;
 
 use std::collections::BTreeMap;
@@ -21,6 +23,28 @@ pub type TypeMap = BTreeMap<TypeId, Type>;
 pub type Stack = Vec<TypeId>;
 pub type Frame = Vec<(String, FramedType)>;
 
+pub fn stack_compare(input: &Stack, stack: &Stack, types: &TypeMap, variance: Variance) -> bool {
+    for (input, stk) in stack.iter().rev().zip(input.iter().rev()) {
+        let v = Variance::new(input, stk, types);
+        // println!("{input} is {v:?} to {stk} ");
+        if v > variance {
+            return false;
+        }
+    }
+    true
+}
+
+pub fn stack_compare_exact(
+    input: &Stack,
+    stack: &Stack,
+    types: &TypeMap,
+    variance: Variance,
+) -> bool {
+    if stack.len() != input.len() {
+        return false;
+    }
+    stack_compare(input, stack, types, variance)
+}
 mod tests {
 
     #[test]

--- a/src/types/mod.rs
+++ b/src/types/mod.rs
@@ -23,10 +23,14 @@ pub type TypeMap = BTreeMap<TypeId, Type>;
 pub type Stack = Vec<TypeId>;
 pub type Frame = Vec<(String, FramedType)>;
 
-pub fn stack_compare(input: &Stack, stack: &Stack, types: &TypeMap, variance: Variance) -> bool {
+pub fn stack_compare(
+    input: &Stack,
+    stack: &Stack,
+    types: &mut TypeMap,
+    variance: Variance,
+) -> bool {
     for (input, stk) in stack.iter().rev().zip(input.iter().rev()) {
         let v = Variance::new(input, stk, types);
-        // println!("{input} is {v:?} to {stk} ");
         if v > variance {
             return false;
         }
@@ -37,7 +41,7 @@ pub fn stack_compare(input: &Stack, stack: &Stack, types: &TypeMap, variance: Va
 pub fn stack_compare_exact(
     input: &Stack,
     stack: &Stack,
-    types: &TypeMap,
+    types: &mut TypeMap,
     variance: Variance,
 ) -> bool {
     if stack.len() != input.len() {

--- a/src/types/record_kind.rs
+++ b/src/types/record_kind.rs
@@ -5,6 +5,7 @@ pub enum RecordKind {
     Union,
     EnumStruct,
     Interface,
+    Tuple,
 }
 
 impl std::fmt::Display for RecordKind {
@@ -14,6 +15,7 @@ impl std::fmt::Display for RecordKind {
             RecordKind::Union => write!(f, "union"),
             RecordKind::Interface => write!(f, "interface"),
             RecordKind::EnumStruct => write!(f, "enum struct"),
+            RecordKind::Tuple => write!(f, "tuple"),
         }
     }
 }

--- a/src/types/type.rs
+++ b/src/types/type.rs
@@ -41,6 +41,7 @@ pub enum Type {
     Never,
     Tuple {
         inner: Vec<TypeId>,
+        idents: Option<Vec<Token>>,
     },
     /// Pointer type.
     Pointer {
@@ -161,7 +162,10 @@ impl Type {
 
                 TypeId::new(name)
             }
-            Type::Tuple { inner } => {
+            Type::Tuple {
+                inner,
+                idents: None,
+            } => {
                 let mut name = format!("[{}", inner.first().unwrap_or(&TypeId::new("")));
                 if !inner.is_empty() {
                     for t in &inner[1..] {
@@ -170,6 +174,31 @@ impl Type {
                 }
 
                 name = format!("{name}]",);
+
+                TypeId::new(name)
+            }
+            Type::Tuple {
+                inner,
+                idents: Some(idents),
+            } => {
+                let mut name = format!(
+                    "{{{}: {}",
+                    inner.first().unwrap_or(&TypeId::new("")),
+                    idents
+                        .first()
+                        .map(|tok| &tok.lexeme)
+                        .unwrap_or(&String::new())
+                );
+                if !inner.is_empty() {
+                    for (t, id) in inner[1..]
+                        .iter()
+                        .zip(idents[1..].iter().map(|tok| &tok.lexeme))
+                    {
+                        name = format!("{name} {t}: {id}");
+                    }
+                }
+
+                name = format!("{name}}}",);
 
                 TypeId::new(name)
             }

--- a/src/types/type_id.rs
+++ b/src/types/type_id.rs
@@ -922,8 +922,6 @@ impl TypeId {
                     (Some(idents), Some(concrete_idents)) if idents.iter().zip(concrete_idents.iter()).any(|(i, c)| {
                         i.lexeme != c.lexeme
                     }) => return Err(HayError::new(format!("Cannot resolve {self} from {concrete}"), token.loc.clone())),
-                    (Some(_) , None)
-                    | (None, Some(_)) => return Err(HayError::new(format!("Cannot resolve {self} from {concrete}"), token.loc.clone())),
                     _ => (),    
                 }
 

--- a/src/types/type_id.rs
+++ b/src/types/type_id.rs
@@ -912,17 +912,10 @@ impl TypeId {
 
                 Ok(concrete.clone())
             }
-            (Some(Type::Tuple { inner, idents }), Some(Type::Tuple { inner: concrete_inner, idents: concrete_idents })) => {
+            (Some(Type::Tuple { inner, .. }), Some(Type::Tuple { inner: concrete_inner, .. })) => {
 
                 if inner.len() != concrete_inner.len() {
                     return Err(HayError::new(format!("Cannot resolve {self} from {concrete}"), token.loc.clone()));
-                }
-
-                match (idents, concrete_idents) {
-                    (Some(idents), Some(concrete_idents)) if idents.iter().zip(concrete_idents.iter()).any(|(i, c)| {
-                        i.lexeme != c.lexeme
-                    }) => return Err(HayError::new(format!("Cannot resolve {self} from {concrete}"), token.loc.clone())),
-                    _ => (),    
                 }
 
                 for (t, c) in inner.into_iter().zip(concrete_inner.iter()) {

--- a/src/types/type_id.rs
+++ b/src/types/type_id.rs
@@ -8,8 +8,6 @@ use std::hash::Hash;
 
 use super::VariantType;
 
-
-
 /// Unique Identifier for types
 ///
 /// This is just a wrapper around a string, which is used as an identifier

--- a/src/types/variance.rs
+++ b/src/types/variance.rs
@@ -1,4 +1,4 @@
-use super::{TypeId, TypeMap};
+use super::{Type, TypeId, TypeMap};
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
 pub enum Variance {
@@ -10,11 +10,39 @@ pub enum Variance {
 
 impl Variance {
     pub fn new(t1: &TypeId, t2: &TypeId, types: &TypeMap) -> Self {
+        let t1 = match types.get(t1) {
+            Some(Type::Tuple {
+                inner,
+                idents: Some(_),
+            }) => {
+                let t = Type::Tuple {
+                    inner: inner.clone(),
+                    idents: None,
+                };
+                t.id()
+            }
+            _ => t1.clone(),
+        };
+
+        let t2 = match types.get(t2) {
+            Some(Type::Tuple {
+                inner,
+                idents: Some(_),
+            }) => {
+                let t = Type::Tuple {
+                    inner: inner.clone(),
+                    idents: None,
+                };
+                t.id()
+            }
+            _ => t2.clone(),
+        };
+
         if t1 == t2 {
             Variance::Variant
-        } else if t1 == &t2.supertype(types) {
+        } else if t1 == t2.supertype(types) {
             Variance::Contravariant
-        } else if &t1.supertype(types) == t2 {
+        } else if t1.supertype(types) == t2 {
             Variance::Covariant
         } else {
             Variance::Invariant

--- a/src/types/variance.rs
+++ b/src/types/variance.rs
@@ -1,0 +1,23 @@
+use super::{TypeId, TypeMap};
+
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Copy)]
+pub enum Variance {
+    Variant = 0,
+    Covariant = 1,
+    Contravariant = 2,
+    Invariant = 3,
+}
+
+impl Variance {
+    pub fn new(t1: &TypeId, t2: &TypeId, types: &TypeMap) -> Self {
+        if t1 == t2 {
+            Variance::Variant
+        } else if t1 == &t2.supertype(types) {
+            Variance::Contravariant
+        } else if &t1.supertype(types) == t2 {
+            Variance::Covariant
+        } else {
+            Variance::Invariant
+        }
+    }
+}

--- a/src/types/variance.rs
+++ b/src/types/variance.rs
@@ -9,7 +9,8 @@ pub enum Variance {
 }
 
 impl Variance {
-    pub fn new(t1: &TypeId, t2: &TypeId, types: &TypeMap) -> Self {
+    pub fn new(t1: &TypeId, t2: &TypeId, types: &mut TypeMap) -> Self {
+        let mut insert = vec![];
         let t1 = match types.get(t1) {
             Some(Type::Tuple {
                 inner,
@@ -19,7 +20,9 @@ impl Variance {
                     inner: inner.clone(),
                     idents: None,
                 };
-                t.id()
+                let tid = t.id();
+                insert.push(t);
+                tid
             }
             _ => t1.clone(),
         };
@@ -33,10 +36,18 @@ impl Variance {
                     inner: inner.clone(),
                     idents: None,
                 };
-                t.id()
+
+                let tid = t.id();
+                insert.push(t);
+                tid
             }
             _ => t2.clone(),
         };
+
+        for t in insert {
+            let id = t.id();
+            types.insert(id, t);
+        }
 
         if t1 == t2 {
             Variance::Variant


### PR DESCRIPTION
Adds support for anonymous structures which are interchangeable with tuples with the same types.

These types are declared just like the body of a structure:
```
fn main() {
    1 2 cast({u64: x u64: y}) println // prints `[1 2]`
}
```

They let you add names to members of enum-structs:
```
enum struct Shape {
    {u64: radius}: Circle
    {u64: length u64: width}: Square
}
```

All they do is allow you to use the identifiers instead of the index:
```
fn square_x({u64: x u64: y}: point) -> [[u64 u64]] {
    [ point::x point::x * point::y ]
}
```