### PR TITLE
Add `do` to `while` loops to allow for blocks between `while` and body

### DIFF
--- a/examples/advanced_features.hay
+++ b/examples/advanced_features.hay
@@ -19,7 +19,7 @@ fn add_leaf(Tree: leaf Tree: mut self) -> [Tree] {
 
 fn Tree.print(u64: level &Tree: self) {
 
-    0 while dup level < {
+    0 while dup level < do {
         as [i]
         '\t' print
         i 1 + 
@@ -27,7 +27,7 @@ fn Tree.print(u64: level &Tree: self) {
 
     self::value @ println
 
-    0 while dup self::leaves Vec.len < {
+    0 while dup self::leaves Vec.len < do {
         as [i]
         level 1 + i self::leaves Vec.get Option.unwrap Tree.print
         i 1 +

--- a/examples/fizzbuzz.hay
+++ b/examples/fizzbuzz.hay
@@ -11,7 +11,7 @@ fn fizzbuzz(u64: n) {
 }
 
 fn main() {
-    0 while dup 100 < {
+    0 while dup 100 < do {
         as [i]
         "i: " print i print " -> " print
         i fizzbuzz

--- a/examples/generics.hay
+++ b/examples/generics.hay
@@ -71,7 +71,7 @@ fn main() {
         "Unwrapped err value: " print err MyResult.unwrap_err println 
     }
 
-    0 while dup 10 < {
+    0 while dup 10 < do {
         as [i]
         i might_fail as [r] {
             r MyResult.is_ok if {

--- a/examples/loops_and_branching.hay
+++ b/examples/loops_and_branching.hay
@@ -25,11 +25,11 @@ fn fib(u64: n) -> [u64] {
 fn main() {
 
     //Uncomment this loop to see the compiler error
-    //while true {
+    //while true do {
     //    1
     //}
 
-    0 while dup 20 < {
+    0 while dup 20 < do {
         as [i]
         i fib println
         i 1 + 

--- a/examples/pointers.hay
+++ b/examples/pointers.hay
@@ -10,7 +10,7 @@ fn example() {
 
 fn main() {
     "Hello World" as [s]
-    0 while dup s::size < {
+    0 while dup s::size < do {
         as [i]
         s::data i
         ptr+ // ptr+ offsets a pointer by `i`
@@ -29,7 +29,7 @@ fn main() {
 
     numbers @ as [nums]
 
-    0 while dup nums::size < {
+    0 while dup nums::size < do {
         as [i]
         i nums Arr.get println
         i 1 +

--- a/src/ast/parser.rs
+++ b/src/ast/parser.rs
@@ -1794,11 +1794,10 @@ impl<'a> Parser<'a> {
 
     fn parse_while(&mut self, token: Token) -> Result<Box<Expr>, HayError> {
         let mut cond = vec![];
-        while !self.check(TokenKind::Marker(Marker::LeftBrace)) {
+        while self.matches(TokenKind::Keyword(Keyword::Do)).is_err() {
             cond.push(*self.expression()?);
         }
-        let open = self.tokens.pop().unwrap();
-        let body = self.block(open)?;
+        let body = self.expression()?;
 
         Ok(Box::new(Expr::While(ExprWhile { token, cond, body })))
     }

--- a/src/ast/parser.rs
+++ b/src/ast/parser.rs
@@ -1795,7 +1795,10 @@ impl<'a> Parser<'a> {
     fn parse_while(&mut self, token: Token) -> Result<Box<Expr>, HayError> {
         let mut cond = vec![];
         while self.matches(TokenKind::Keyword(Keyword::Do)).is_err() {
-            cond.push(*self.expression()?);
+            cond.push(*self.expression().map_err(|_| HayError::new(
+                format!("Expected {} after {} to mark loop body.", Keyword::Do, Keyword::While), 
+                token.loc.clone()))?
+            );
         }
         let body = self.expression()?;
 
@@ -2289,6 +2292,11 @@ mod tests {
     #[test]
     fn anon_struct_bad_close() -> Result<(), std::io::Error> {
         crate::compiler::test_tools::run_test("src/tests/parser", "anon_struct_bad_close", None)
+    }
+
+    #[test]
+    fn parse_while_without_do() -> Result<(), std::io::Error> {
+        crate::compiler::test_tools::run_test("src/tests/parser", "parse_while_without_do", None)
     }
 
 }

--- a/src/lex/token.rs
+++ b/src/lex/token.rs
@@ -164,6 +164,7 @@ pub enum Keyword {
     If,
     Else,
     While,
+    Do,
     Struct,
     Union,
     Enum,
@@ -191,6 +192,7 @@ impl std::fmt::Display for Keyword {
             Keyword::If => write!(f, "if")?,
             Keyword::Else => write!(f, "else")?,
             Keyword::While => write!(f, "while")?,
+            Keyword::Do => write!(f, "do")?,
             Keyword::Struct => write!(f, "struct")?,
             Keyword::Union => write!(f, "union")?,
             Keyword::Enum => write!(f, "enum")?,
@@ -220,6 +222,7 @@ impl Keyword {
         map.insert("if", TokenKind::Keyword(Keyword::If));
         map.insert("else", TokenKind::Keyword(Keyword::Else));
         map.insert("while", TokenKind::Keyword(Keyword::While));
+        map.insert("do", TokenKind::Keyword(Keyword::Do));
         map.insert("struct", TokenKind::Keyword(Keyword::Struct));
         map.insert("union", TokenKind::Keyword(Keyword::Union));
         map.insert("enum", TokenKind::Keyword(Keyword::Enum));

--- a/src/tests/functional/address_of_framed.hay
+++ b/src/tests/functional/address_of_framed.hay
@@ -28,12 +28,12 @@ impl:
 fn main() {
 
     12345 MyVec.new::<u64> "Hello World" as [n mut list str]
-    0 while dup 10 < {
+    0 while dup 10 < do {
         dup *list MyVec.push
         1 +
     } drop
 
-    0 while dup 10 < {
+    0 while dup 10 < do {
         dup *list MyVec.get println
         1 +
     } drop

--- a/src/tests/functional/array.hay
+++ b/src/tests/functional/array.hay
@@ -8,7 +8,7 @@ fn main() {
     "Hello World2\n" 1 x Arr.set
     "Hello World3\n" 2 x Arr.set
 
-    0 while dup 3 < {
+    0 while dup 3 < do {
         as [i]
         i x Arr.get print
         i 1 + 
@@ -17,7 +17,7 @@ fn main() {
     "aaaaabbbbbccccc" as [s] { s::size s::data } cast(ConstArr)
     as [str_arr]
 
-    0 while dup str_arr::size < {
+    0 while dup str_arr::size < do {
         as [i]
         i str_arr ConstArr.get cast(u64) println
         i 1 +

--- a/src/tests/functional/array_of_tuples.hay
+++ b/src/tests/functional/array_of_tuples.hay
@@ -3,13 +3,13 @@ var [u64 u64][15]: ArrayOfTuples_p
 fn main() {
 
     ArrayOfTuples_p @ as [tuples] 
-    0 while dup 15 < {
+    0 while dup 15 < do {
         as [i]
         i i 2 * cast([u64 u64]) i tuples Arr.set
         i 1 +
     } drop
 
-    0 while dup 15 < {
+    0 while dup 15 < do {
         as [i]
         i tuples Arr.get println
         i 1 + 

--- a/src/tests/functional/blanket_impl.hay
+++ b/src/tests/functional/blanket_impl.hay
@@ -40,13 +40,13 @@ fn main() {
 
     Vec.new::<u64> as [mut v]
 
-	0 while dup 10 < {
+	0 while dup 10 < do {
 		as [i] 
 		i *v Vec.push
 		i 1 +
 	} drop 
 
-	while *v my_next {
+	while *v my_next do {
 		Option.unwrap my_println
 	} drop
 

--- a/src/tests/functional/early_return_if_else_while.hay
+++ b/src/tests/functional/early_return_if_else_while.hay
@@ -4,7 +4,7 @@ fn do_work(Option<u64>: maybe) -> [Option<bool>] {
         Option.None::<bool> return
     }
 
-    while true {
+    while true do {
         maybe Option.unwrap 10 < Option.Some return 
     }
     

--- a/src/tests/functional/early_return_while_condition.hay
+++ b/src/tests/functional/early_return_while_condition.hay
@@ -1,6 +1,6 @@
 fn foo() -> [u64] {
 
-    while 42 return {
+    while 42 return do {
         "unreachable" println
     }
 

--- a/src/tests/functional/enum_variants_loop.hay
+++ b/src/tests/functional/enum_variants_loop.hay
@@ -12,7 +12,7 @@ impl Print<Foo> {
 
 fn main() {
 
-    Foo::Bar 0 while dup 2 < {
+    Foo::Bar 0 while dup 2 < do {
         as [i]
         println
         Foo::Baz

--- a/src/tests/functional/local.hay
+++ b/src/tests/functional/local.hay
@@ -3,7 +3,7 @@ fn copy_local(Str: s) {
     
     nums @ as [arr]
     
-    0 while dup s::size < {
+    0 while dup s::size < do {
         as [i]
         s::data i ptr+ @
         i arr Arr.set

--- a/src/tests/functional/pointer.hay
+++ b/src/tests/functional/pointer.hay
@@ -3,7 +3,7 @@ fn main() {
     var char[64]: chars
 
     "Hello World!" as [word]
-    0 while dup word::size < {
+    0 while dup word::size < do {
         as [i]
         word::data i ptr+ @ 
         chars::data @ i ptr+_mut !

--- a/src/tests/functional/vec.hay
+++ b/src/tests/functional/vec.hay
@@ -4,7 +4,7 @@ fn main() {
     Vec.new::<u64> as [mut vec]
     "Initial capacity: " print &vec Vec.capacity println
     
-    0 while dup 4069 < {
+    0 while dup 4069 < do {
         as [i]
         i *vec Vec.push
         i 1 +
@@ -20,7 +20,7 @@ fn main() {
     4069 *vec Vec.get_mut as [x] &x Option.is_none assert
     4069 &vec Vec.at      as [x] &x Option.is_none assert
 
-    0 while &vec Vec.len 0 > {
+    0 while &vec Vec.len 0 > do {
         *vec Vec.pop Option.unwrap drop
         1 +
     }

--- a/src/tests/functional/vec_formatting.hay
+++ b/src/tests/functional/vec_formatting.hay
@@ -1,7 +1,7 @@
 fn main() {
 
     Vec.new::<u64> as [mut v]
-    0 while dup 10 < {
+    0 while dup 10 < do {
         as [i]
         "" String.new &v fmt println
         i *v Vec.push

--- a/src/tests/parser/parse_while_without_do.hay
+++ b/src/tests/parser/parse_while_without_do.hay
@@ -1,0 +1,9 @@
+fn main() {
+
+    0 while dup 10 < {
+        as [i]
+        i println
+        i 1 +
+    } drop
+
+}

--- a/src/tests/parser/parse_while_without_do.try_com
+++ b/src/tests/parser/parse_while_without_do.try_com
@@ -1,0 +1,5 @@
+{
+  "exit_code": 1,
+  "stdout": "",
+  "stderr": "[src/tests/parser/parse_while_without_do.hay:3:7] Error: Expected `do` after `while` to mark loop body.\n"
+}

--- a/src/tests/type_check/while_changes_frame.hay
+++ b/src/tests/type_check/while_changes_frame.hay
@@ -1,3 +1,3 @@
 fn main() {
-    while true as [b] b { }
+    while true as [b] b do { }
 }

--- a/src/tests/type_check/while_changes_stack.hay
+++ b/src/tests/type_check/while_changes_stack.hay
@@ -1,6 +1,6 @@
 fn main() {
 
-    while true {
+    while true do {
         1
     }
 

--- a/src/tests/type_check/while_loop_push_before_condition.hay
+++ b/src/tests/type_check/while_loop_push_before_condition.hay
@@ -2,7 +2,7 @@ fn main() {
 
     Vec.new::<u64> as [mut vec]
 
-    while *vec Vec.pop dup Option.take_is_some {
+    while *vec Vec.pop dup Option.take_is_some do {
         drop
     }
 

--- a/std/alloc.hay
+++ b/std/alloc.hay
@@ -18,7 +18,7 @@ fn Chunk.next(*Block: blk_p) -> [*Block] {
 fn Chunk.print(Chunk: chunk) {
     "[" print 
     chunk::start cast(u64) chunk::cap + cast(u64) as [end]
-    0 chunk::start cast(u64) while dup end < {
+    0 chunk::start cast(u64) while dup end < do {
 
         cast(*Block) as [n blk_p]
         blk_p @ as [blk]
@@ -37,7 +37,7 @@ fn Heap.debug_summary() {
     
     chunks_p @ as [chunks]
     "Heap:" println
-    0 while dup n_chunks_p @ < {
+    0 while dup n_chunks_p @ < do {
         as [i]
         "  * " print i chunks Arr.get Chunk.print
         i 1 +
@@ -59,6 +59,7 @@ fn Chunk.try_alloc(u64: n *Chunk: chunk_p) -> [Option<Arr<u8>>] {
     while 
         &maybe_alloc Option.is_none 
         block_p cast(u64) end cast(u64) < land
+    do
     {
         block_p cast(u64) cast(*u8) as [void_block_p]
         block_p @ as [block] 
@@ -109,7 +110,7 @@ fn Chunk.consolidate(*Chunk: chunk_p) {
     
     chunk_p @ as [chunk]
     chunk::start cast(u64) chunk::cap + as [end]
-    chunk::start chunk::start Chunk.next while dup cast(u64) end < {
+    chunk::start chunk::start Chunk.next while dup cast(u64) end < do {
 
         as [first_p second_p]
         first_p @ second_p @ as [first second]
@@ -203,7 +204,7 @@ fn malloc<T>(u64: count) -> [Arr<T>] {
         0 while
             dup n_chunks <
             &maybe_alloc Option.is_none land
-        {
+        do {
             // clear the previous option and capture the index
             as [idx]
             idx chunks Arr.get_ref_mut as [chunk_p]
@@ -238,7 +239,7 @@ fn find_chunk<T>(Arr<T>: arr) -> [Option<*Chunk>] {
     0 while
         dup n_chunks <
         &maybe_blk Option.is_none land
-    {
+    do {
         as [n]
         n chunks Arr.get as [chunk]
         
@@ -264,7 +265,7 @@ fn free<T>(Arr<T>: arr) {
         maybe_chunk Option.unwrap as [chunk_p] 
         chunk_p @ as [chunk]
         arr::data cast(u64) sizeOf(Block) - cast(*Block) as [blk_p]
-        chunk::start while dup cast(u64) blk_p cast(u64) <= {
+        chunk::start while dup cast(u64) blk_p cast(u64) <= do {
             as [chunk_blk_p]
             chunk_blk_p cast(u64) blk_p cast(u64) == if {
                 blk_p @ as [blk]

--- a/std/arr.hay
+++ b/std/arr.hay
@@ -41,7 +41,7 @@ impl:
     fn Arr.rev<T>(Arr<T>: arr) {
 
         0 arr::size 1 - 
-        while over over < {
+        while over over < do {
 
             as [start_idx end_idx]
             start_idx arr Arr.get

--- a/std/builtin/u64.hay
+++ b/std/builtin/u64.hay
@@ -9,7 +9,7 @@ fn u64.to_str(u64: u Arr<char>: chars) -> [Str] {
         "0" as [str] { str::size str::data } chars::data memcpy
         1 chars::data cast(Str) 
     } else {
-        19 u while dup 0 != {
+        19 u while dup 0 != do {
             as [i x]
             x 10 % cast(char) '0' + chars::data i ptr+_mut !
             

--- a/std/linear_map.hay
+++ b/std/linear_map.hay
@@ -31,7 +31,7 @@ impl:
     }
 
     fn Map.get_mut<T>(Str: key *Map<T>: self) -> [Option<*T>] {
-        0 while dup self::keys Vec.len < {
+        0 while dup self::keys Vec.len < do {
             as [i]
 
             key i self::keys Vec.at Option.unwrap Str.equals if {
@@ -45,7 +45,7 @@ impl:
     }
 
     fn Map.get<T>(Str: key &Map<T>: self) -> [Option<&T>] {
-        0 while dup self::keys Vec.len < {
+        0 while dup self::keys Vec.len < do {
             as [i]
             key i self::keys Vec.at Option.unwrap Str.equals if {
                 i self::values Vec.get return 

--- a/std/prelude.hay
+++ b/std/prelude.hay
@@ -35,14 +35,14 @@ fn ptr-diff<T>(*T: ptr1 *T:  ptr2) -> [u64] {
     - sizeOf(T) /
 }
 fn memset<T>(T: value Arr<T>: range) {
-    0 while dup range::size < {
+    0 while dup range::size < do {
         as [i]
         value range::data i ptr+_mut !
         i 1 +
     } drop
 }
 fn memcpy<T>(u64: n &T: src *T: dest) {
-    0 while dup n < {
+    0 while dup n < do {
         as [i]
         src i ptr+ @
         dest i ptr+_mut !

--- a/std/str.hay
+++ b/std/str.hay
@@ -11,7 +11,7 @@ impl:
         s1::size s2::size != if {
             false return
         }
-        0 while dup s1::size < {
+        0 while dup s1::size < do {
             as [i]
             s1::data i ptr+ @ 
             s2::data i ptr+ @ != if {

--- a/std/string.hay
+++ b/std/string.hay
@@ -10,7 +10,7 @@ impl:
 
     fn String.new(Str: s) -> [String] {
         s::size Vec.with_capacity::<char> as [mut chars]
-        0 while dup s::size < {
+        0 while dup s::size < do {
             as [i]
             s::data i ptr+ @ *chars Vec.push
             i 1 +
@@ -49,7 +49,7 @@ impl:
     }
 
     fn String.push_str(String: mut self Str: s) -> [String] {
-        0 while dup s::size < {
+        0 while dup s::size < do {
             as [i]
             s::data i ptr+ @ *self::chars Vec.push
             i 1 +
@@ -59,7 +59,7 @@ impl:
 
     fn String.format(String: mut self String: other) -> [String] {
         self 
-        0 while dup &other String.size < {
+        0 while dup &other String.size < do {
             as [i]
             i &other::chars Vec.at Option.unwrap String.push
             i 1 +

--- a/std/vec.hay
+++ b/std/vec.hay
@@ -91,7 +91,7 @@ impl:
 
     fn Vec.contains<T>(T: item &Vec<T>: self) -> [bool] {
 
-        0 while dup self Vec.len < {
+        0 while dup self Vec.len < do {
             as [i]
             i self Vec.at Option.unwrap item == if {
                 true return
@@ -106,11 +106,11 @@ impl:
     fn Vec.append<T>(*Vec<T>: other *Vec<T>: self) {
         Vec.new::<T> as [mut temp]
 
-        while other Vec.is_empty lnot {
+        while other Vec.is_empty lnot do {
             other Vec.pop Option.unwrap *temp Vec.push
         }
 
-        while &temp Vec.is_empty lnot {
+        while &temp Vec.is_empty lnot do {
             *temp Vec.pop Option.unwrap self Vec.push
         }
 
@@ -121,7 +121,7 @@ impl:
     fn Vec.reverse<T>(Vec<T>: mut self) -> [Vec<T>] {
 
         Vec.new::<T> as [mut rev]
-        while &self Vec.is_empty lnot {
+        while &self Vec.is_empty lnot do {
             *self Vec.pop Option.unwrap *rev Vec.push
         }
 
@@ -139,7 +139,7 @@ requires: [Format<T>] {
         self Vec.len 0 == if { "[ ]" fmt return }
         
         '[' fmt
-        0 while dup self Vec.len 1 - < {
+        0 while dup self Vec.len 1 - < do {
             as [i]
             i self Vec.get Option.unwrap @ fmt
             ' '              fmt


### PR DESCRIPTION
Now `while` loops require a `do` to mark where the body of the while loop begins. Loop body is now _actually_ just an expression.

```rust 
fn inc(u64) -> [u64] { 1 + }
 
fn main() {
    0 while { 
        as [i] i 
        i 10 < 
    } do inc
    println // prints 10
}
```

closes #195 