### PR TITLE
Adds initial docstrings for ´std/vec´

### DIFF
--- a/std/option.hay
+++ b/std/option.hay
@@ -19,6 +19,10 @@ impl:
         &option Option.is_some
     }
 
+    inline fn Option.take_is_none<T>(Option<T>: option) -> [bool] {
+        &option Option.is_none
+    }
+
     inline fn Option.unwrap<T>(Option<T>) -> [T] match {
         Option::Some as [t] { t }
         Option::None { 

--- a/std/vec.hay
+++ b/std/vec.hay
@@ -34,14 +34,21 @@ impl:
         cast(ConstArr)
     }
 
-    // Add an element to the end of the vector.
+    // Adds an element to the end of the vector.
     //
-    // Parameters:
-    // - `value`: the value to add to the vector
-    // - `self`: a mutable reference to the vector to add the value to
+    // Inputs:
+    // - `T (value)`: the value to add to the vector
+    // - `*Vec<T> (self)`: a mutable reference to the vector to add the value to
     //
-    // Return value:
+    // Output:
     // - This function returns `()` and does not allocate a new vector.
+    //
+    // Example:
+    // ```
+    // Vec.new::<u64> as [mut v]
+    // 12345 *v Vec.push
+    // 0 &v Vec.at Option.unwrap 12345 == assert
+    // ```
     fn Vec.push<T>(T: value *Vec<T>: self) {
         self::len @ 0 == if {
             2 self::slice @ realloc self::slice ! 
@@ -52,13 +59,21 @@ impl:
         self::len @ 1 + self::len !
     }
 
-    // Pop the last element off the vector and return it inside of an `Option`, or return `Option.None` if the vector is empty.
+    // Pops the last element off the vector and return it inside of an `Option`, 
+    // or return `Option.None` if the vector is empty.
     //
-    // Parameters:
-    // - `self`: the vector to pop from
+    // Inputs:
+    // - `*Vec<T> (self)`: a mutable reference to the vector to pop from
     //
-    // Return value:
+    // Output:
     // - An `Option` containing the popped element, or `Option.None` if the vector is empty.
+    //
+    // Example:
+    // ```
+    // Vec.new::<u64> as [mut v]
+    // 12345 *v Vec.push
+    // 12345 v Vec.pop Option.unwrap 12345 == assert
+    // ```
     fn Vec.pop<T>(*Vec<T>: self) -> [Option<T>] {
         self::len @ 0 == if {
             Option.None::<T>
@@ -68,14 +83,28 @@ impl:
         }
     }
 
-    // Get a reference to the element at the given index in the vector, or return `Option.None` if the index is out of bounds.
+    // Get a reference to the element at the given index in the vector, 
+    // or return `Option.None` if the index is out of bounds.
     //
-    // Parameters:
-    // - `idx`: the index of the element to get
-    // - `self`: the vector to get the element from
+    // Inputs:
+    // - `u64 (idx)`: the index of the element to get
+    // - `&Vec<T> (self)`: a reference to the vector to get the element from
     //
-    // Return value:
-    // - An `Option` containing a reference to the requested element, or `Option.None` if the index is out of bounds.
+    // Output:
+    // - An `Option` containing a reference to the requested element, 
+    //   or `Option.None` if the index is out of bounds.
+    //
+    // Example:
+    // ```
+    // Vec.new::<u64> as [mut v]
+    // 10 *v Vec.push
+    // 20 *v Vec.push
+    // 30 *v Vec.push
+    // 40 *v Vec.push
+    // 0 &v Vec.get Option.unwrap == 10 assert
+    // 3 &v Vec.get Option.unwrap == 40 assert
+    // 5 &v Vec.get Option.unwrap Option.None == assert
+    // ```
     fn Vec.get<T>(u64: idx &Vec<T>: self) -> [Option<&T>] {
         idx self::len @ >= if {
             Option.None::<&T>
@@ -86,12 +115,19 @@ impl:
 
     // Get a mutable reference to the element at the given index in the vector, or return `Option.None` if the index is out of bounds.
     //
-    // Parameters:
-    // - `idx`: the index of the element to get
-    // - `self`: a mutable reference to the vector to get the element from
+    // Inputs:
+    // - `u64 (idx)`: the index of the element to get
+    // - `*Vec<T> (self)`: a mutable reference to the vector to get the element from
     //
-    // Return value:
+    // Output:
     // - An `Option` containing a mutable pointer to the requested element, or `Option.None` if the index is out of bounds.
+    //
+    // Example:
+    // ```
+    // Vec.new::<u64> as [mut v]
+    // 12345 *v Vec.push
+    // *v 0 Vec.get_mut Option.unwrap 12345 == assert
+    // ```
     fn Vec.get_mut<T>(u64: idx *Vec<T>: self) -> [Option<*T>] {
         idx self::len @ >= if {
             Option.None::<*T>
@@ -102,12 +138,20 @@ impl:
 
     // Return an `Option` containing a reference to the element at the specified index in the vector, or `Option.None` if the index is out of bounds.
     //
-    // Parameters:
+    // Inputs:
     // - `idx`: the index of the element to retrieve
-    // - `self`: a reference to the vector to retrieve the element from
+    // - `&Vec<T> (self)`: a reference to the vector to retrieve the element from
     //
-    // Return value:
+    // Output:
     // - An `Option` containing a reference to the requested element, or `Option.None` if the index is out of bounds.
+    //
+    // Example:
+    // ```
+    // Vec.new::<u64> as [mut v]
+    // 12345 *v Vec.push
+    // 0 &v Vec.at Option.unwrap 12345 == assert
+    // 1 &v Vec.at Option.None == assert
+    // ```
     fn Vec.at<T>(u64: idx &Vec<T>: self) -> [Option<T>] {
         idx self::len @ >= if {
             Option.None::<T>
@@ -116,47 +160,76 @@ impl:
         }
     }
 
-    // Return an `Option` containing a reference to the last element in the vector, or `Option.None` if the vector is empty.
+    // Return an `Option` containing a reference to the last element in the vector, 
+    // or `Option.None` if the vector is empty.
     //
-    // Parameters:
-    // - `self`: a reference to the vector to retrieve the last element from
+    // Inputs:
+    // - `&Vec<T> (self)`: a reference to the vector to retrieve the last element from
     //
-    // Return value:
-    // - An `Option` containing a reference to the last element in the vector, or `Option.None` if the vector is empty.
+    // Output:
+    // - An `Option` containing a reference to the last element in the vector, 
+    // or `Option.None` if the vector is empty.
+    //
+    // Example:
+    // ```
+    // Vec.new::<u64> as [mut v]
+    // 123 *v Vec.push
+    // 456 *v Vec.push
+    // &v Vec.last Option.unwrap 456 == assert
+    // ```
     inline fn Vec.last<T>(&Vec<T>: self) -> [Option<&T>] {
         self::len @ 1- self Vec.get
     }
 
     // Return the number of elements that the vector can hold without reallocating its underlying storage.
     //
-    // Parameters:
+    // Inputs:
     // - `self`: a reference to the vector to retrieve the capacity of
     //
-    // Return value:
+    // Output:
     // - The number of elements that the vector can hold without reallocating its underlying storage.
+    //
+    // Example:
+    // ```
+    // not sure how to do this one :(
+    // ```
     fn Vec.capacity<T>(&Vec<T>: self) -> [u64] {
         self::slice::size @
     }
 
     // Return the number of elements in the vector.
     //
-    // Parameters:
+    // Inputs:
     // - `self`: a reference to the vector to retrieve the length of
     //
-    // Return value:
+    // Output:
     // - The number of elements in the vector.
+    //
+    // Example:
+    // ```
+    // Vec.new::<u64> as [mut v]
+    // 123 *v Vec.push
+    // 456 *v Vec.push
+    // &v Vec.len 2 == assert
+    // ```
     fn Vec.len<T>(&Vec<T>: self) -> [u64] {
         self::len @
     }
 
     // Check if the vector contains a given element.
     //
-    // Parameters:
+    // Inputs:
     // - `item`: the element to search for
     // - `self`: a reference to the vector to search in
     //
-    // Return value:
+    // Output:
     // - `true` if the vector contains the given element, `false` otherwise.
+    //
+    // Example:
+    // ```
+    // [1 2 3 4] 3 Vec.contains true == assert
+    // [1 2 3 4] 5 Vec.contains false == assert
+    // ```
     fn Vec.contains<T>(T: item &Vec<T>: self) -> [bool] {
 
         0 while dup self Vec.len < do {
@@ -173,12 +246,21 @@ impl:
 
     // Append the elements of another vector to this vector.
     //
-    // Parameters:
+    // Inputs:
     // - `other`: a mutable reference to the vector whose elements to append to `self`.
     // - `self`: a mutable reference to the vector to append the elements to.
     //
-    // Return value:
+    // Output:
     // - This function returns `()` and does not allocate a new vector.
+    //
+    // Example:
+    // ```
+    // Vec.new::<u64> as [mut v]
+    // Vec.new::<u64> as [mut w]
+    // 123 *v Vec.push
+    // 456 *w Vec.push
+    // *w *v Vec.append Vec.last Option.unwrap 456 == assert
+    // ```
     fn Vec.append<T>(*Vec<T>: other *Vec<T>: self) {
         Vec.new::<T> as [mut temp]
 
@@ -196,11 +278,19 @@ impl:
     
     // Reverse the elements of the vector in place.
     //
-    // Parameters:
+    // Inputs:
     // - `self`: a mutable reference to the vector to reverse.
     //
-    // Return value:
+    // Output:
     // - This function returns a new vector with the reversed elements.
+    //
+    // Example:
+    // ```
+    // Vec.new::<u64> as [mut v]
+    // 123 *v Vec.push
+    // 456 *v Vec.push
+    // &v Vec.last Option.unwrap 123 == assert
+    // ```
     fn Vec.reverse<T>(Vec<T>: mut self) -> [Vec<T>] {
 
         Vec.new::<T> as [mut rev]

--- a/std/vec.hay
+++ b/std/vec.hay
@@ -103,8 +103,7 @@ impl:
     // 40 *v Vec.push
     // 0 &v Vec.get Option.unwrap @ 10 == assert
     // 3 &v Vec.get Option.unwrap @ 40 == assert
-    // 5 &v Vec.get Option.unwrap @ Option.None == assert
-    // 5 &v Vec.get Option.is_none assert
+    // 5 &v Vec.get Option.take_is_none assert
     // ```
     fn Vec.get<T>(u64: idx &Vec<T>: self) -> [Option<&T>] {
         idx self::len @ >= if {

--- a/std/vec.hay
+++ b/std/vec.hay
@@ -104,6 +104,7 @@ impl:
     // 0 &v Vec.get Option.unwrap @ 10 == assert
     // 3 &v Vec.get Option.unwrap @ 40 == assert
     // 5 &v Vec.get Option.unwrap @ Option.None == assert
+    // 5 &v Vec.get Option.is_none assert
     // ```
     fn Vec.get<T>(u64: idx &Vec<T>: self) -> [Option<&T>] {
         idx self::len @ >= if {
@@ -127,7 +128,7 @@ impl:
     // Vec.new::<u64> as [mut v]
     // 12345 *v Vec.push
     // 0 *v Vec.get_mut Option.unwrap @ 12345 == assert
-    // 0 *v Vec.get_mut Option.unwrap 54321 !
+    // 0 *v Vec.get_mut Option.unwrap 54321 swap ! 
     // 0 &v Vec.at Option.unwrap 54321 == assert
     // ```
     fn Vec.get_mut<T>(u64: idx *Vec<T>: self) -> [Option<*T>] {

--- a/std/vec.hay
+++ b/std/vec.hay
@@ -72,7 +72,7 @@ impl:
     // ```
     // Vec.new::<u64> as [mut v]
     // 12345 *v Vec.push
-    // 12345 v Vec.pop Option.unwrap 12345 == assert
+    // *v Vec.pop Option.unwrap 12345 == assert
     // ```
     fn Vec.pop<T>(*Vec<T>: self) -> [Option<T>] {
         self::len @ 0 == if {
@@ -101,9 +101,9 @@ impl:
     // 20 *v Vec.push
     // 30 *v Vec.push
     // 40 *v Vec.push
-    // 0 &v Vec.get Option.unwrap == 10 assert
-    // 3 &v Vec.get Option.unwrap == 40 assert
-    // 5 &v Vec.get Option.unwrap Option.None == assert
+    // 0 &v Vec.get Option.unwrap @ 10 == assert
+    // 3 &v Vec.get Option.unwrap @ 40 == assert
+    // 5 &v Vec.get Option.unwrap @ Option.None == assert
     // ```
     fn Vec.get<T>(u64: idx &Vec<T>: self) -> [Option<&T>] {
         idx self::len @ >= if {
@@ -126,7 +126,9 @@ impl:
     // ```
     // Vec.new::<u64> as [mut v]
     // 12345 *v Vec.push
-    // *v 0 Vec.get_mut Option.unwrap 12345 == assert
+    // 0 *v Vec.get_mut Option.unwrap @ 12345 == assert
+    // 0 *v Vec.get_mut Option.unwrap 54321 !
+    // 0 &v Vec.at Option.unwrap 54321 == assert
     // ```
     fn Vec.get_mut<T>(u64: idx *Vec<T>: self) -> [Option<*T>] {
         idx self::len @ >= if {
@@ -175,7 +177,7 @@ impl:
     // Vec.new::<u64> as [mut v]
     // 123 *v Vec.push
     // 456 *v Vec.push
-    // &v Vec.last Option.unwrap 456 == assert
+    // &v Vec.last Option.unwrap @ 456 == assert
     // ```
     inline fn Vec.last<T>(&Vec<T>: self) -> [Option<&T>] {
         self::len @ 1- self Vec.get
@@ -191,7 +193,8 @@ impl:
     //
     // Example:
     // ```
-    // not sure how to do this one :(
+    // Vec.new::<u64> as [v]
+    // &v Vec.capacity 8 == assert
     // ```
     fn Vec.capacity<T>(&Vec<T>: self) -> [u64] {
         self::slice::size @
@@ -227,8 +230,11 @@ impl:
     //
     // Example:
     // ```
-    // [1 2 3 4] 3 Vec.contains true == assert
-    // [1 2 3 4] 5 Vec.contains false == assert
+    // Vec.new::<u64> as [mut v]
+    // 123 *v Vec.push
+    //     
+    // 321 &v Vec.contains false == assert
+    // 123 &v Vec.contains true == assert
     // ```
     fn Vec.contains<T>(T: item &Vec<T>: self) -> [bool] {
 
@@ -259,7 +265,7 @@ impl:
     // Vec.new::<u64> as [mut w]
     // 123 *v Vec.push
     // 456 *w Vec.push
-    // *w *v Vec.append Vec.last Option.unwrap 456 == assert
+    // *w *v Vec.append &v Vec.last Option.unwrap @ 456 == assert
     // ```
     fn Vec.append<T>(*Vec<T>: other *Vec<T>: self) {
         Vec.new::<T> as [mut temp]
@@ -289,7 +295,8 @@ impl:
     // Vec.new::<u64> as [mut v]
     // 123 *v Vec.push
     // 456 *v Vec.push
-    // &v Vec.last Option.unwrap 123 == assert
+    // v Vec.reverse as [w]
+    // &w Vec.last Option.unwrap @ 123 == assert
     // ```
     fn Vec.reverse<T>(Vec<T>: mut self) -> [Vec<T>] {
 

--- a/std/vec.hay
+++ b/std/vec.hay
@@ -34,6 +34,14 @@ impl:
         cast(ConstArr)
     }
 
+    // Add an element to the end of the vector.
+    //
+    // Parameters:
+    // - `value`: the value to add to the vector
+    // - `self`: a mutable reference to the vector to add the value to
+    //
+    // Return value:
+    // - This function returns `()` and does not allocate a new vector.
     fn Vec.push<T>(T: value *Vec<T>: self) {
         self::len @ 0 == if {
             2 self::slice @ realloc self::slice ! 
@@ -44,6 +52,13 @@ impl:
         self::len @ 1 + self::len !
     }
 
+    // Pop the last element off the vector and return it inside of an `Option`, or return `Option.None` if the vector is empty.
+    //
+    // Parameters:
+    // - `self`: the vector to pop from
+    //
+    // Return value:
+    // - An `Option` containing the popped element, or `Option.None` if the vector is empty.
     fn Vec.pop<T>(*Vec<T>: self) -> [Option<T>] {
         self::len @ 0 == if {
             Option.None::<T>
@@ -53,6 +68,14 @@ impl:
         }
     }
 
+    // Get a reference to the element at the given index in the vector, or return `Option.None` if the index is out of bounds.
+    //
+    // Parameters:
+    // - `idx`: the index of the element to get
+    // - `self`: the vector to get the element from
+    //
+    // Return value:
+    // - An `Option` containing a reference to the requested element, or `Option.None` if the index is out of bounds.
     fn Vec.get<T>(u64: idx &Vec<T>: self) -> [Option<&T>] {
         idx self::len @ >= if {
             Option.None::<&T>
@@ -61,6 +84,14 @@ impl:
         }
     }
 
+    // Get a mutable reference to the element at the given index in the vector, or return `Option.None` if the index is out of bounds.
+    //
+    // Parameters:
+    // - `idx`: the index of the element to get
+    // - `self`: a mutable reference to the vector to get the element from
+    //
+    // Return value:
+    // - An `Option` containing a mutable pointer to the requested element, or `Option.None` if the index is out of bounds.
     fn Vec.get_mut<T>(u64: idx *Vec<T>: self) -> [Option<*T>] {
         idx self::len @ >= if {
             Option.None::<*T>
@@ -69,6 +100,14 @@ impl:
         }
     }
 
+    // Return an `Option` containing a reference to the element at the specified index in the vector, or `Option.None` if the index is out of bounds.
+    //
+    // Parameters:
+    // - `idx`: the index of the element to retrieve
+    // - `self`: a reference to the vector to retrieve the element from
+    //
+    // Return value:
+    // - An `Option` containing a reference to the requested element, or `Option.None` if the index is out of bounds.
     fn Vec.at<T>(u64: idx &Vec<T>: self) -> [Option<T>] {
         idx self::len @ >= if {
             Option.None::<T>
@@ -77,18 +116,47 @@ impl:
         }
     }
 
+    // Return an `Option` containing a reference to the last element in the vector, or `Option.None` if the vector is empty.
+    //
+    // Parameters:
+    // - `self`: a reference to the vector to retrieve the last element from
+    //
+    // Return value:
+    // - An `Option` containing a reference to the last element in the vector, or `Option.None` if the vector is empty.
     inline fn Vec.last<T>(&Vec<T>: self) -> [Option<&T>] {
         self::len @ 1- self Vec.get
     }
 
+    // Return the number of elements that the vector can hold without reallocating its underlying storage.
+    //
+    // Parameters:
+    // - `self`: a reference to the vector to retrieve the capacity of
+    //
+    // Return value:
+    // - The number of elements that the vector can hold without reallocating its underlying storage.
     fn Vec.capacity<T>(&Vec<T>: self) -> [u64] {
         self::slice::size @
     }
 
+    // Return the number of elements in the vector.
+    //
+    // Parameters:
+    // - `self`: a reference to the vector to retrieve the length of
+    //
+    // Return value:
+    // - The number of elements in the vector.
     fn Vec.len<T>(&Vec<T>: self) -> [u64] {
         self::len @
     }
 
+    // Check if the vector contains a given element.
+    //
+    // Parameters:
+    // - `item`: the element to search for
+    // - `self`: a reference to the vector to search in
+    //
+    // Return value:
+    // - `true` if the vector contains the given element, `false` otherwise.
     fn Vec.contains<T>(T: item &Vec<T>: self) -> [bool] {
 
         0 while dup self Vec.len < do {
@@ -103,6 +171,14 @@ impl:
 
     }
 
+    // Append the elements of another vector to this vector.
+    //
+    // Parameters:
+    // - `other`: a mutable reference to the vector whose elements to append to `self`.
+    // - `self`: a mutable reference to the vector to append the elements to.
+    //
+    // Return value:
+    // - This function returns `()` and does not allocate a new vector.
     fn Vec.append<T>(*Vec<T>: other *Vec<T>: self) {
         Vec.new::<T> as [mut temp]
 
@@ -117,7 +193,14 @@ impl:
         &temp Vec.delete
 
     }
-
+    
+    // Reverse the elements of the vector in place.
+    //
+    // Parameters:
+    // - `self`: a mutable reference to the vector to reverse.
+    //
+    // Return value:
+    // - This function returns a new vector with the reversed elements.
     fn Vec.reverse<T>(Vec<T>: mut self) -> [Vec<T>] {
 
         Vec.new::<T> as [mut rev]


### PR DESCRIPTION
Refers: #141 

I had no idea what would be a good format to start with, so I tried a mix between rust/dotnet.

This draft is just a sanity check to see if this fits, and I'll expand the PR based on comments before pushing it to a proper review.

Obs:  The reason why this is pointing to master instead of release as requested about on the contribute.md is just to keep the diff short, as the origin release branch is not rebased with main.